### PR TITLE
[fix] always get port number, not name

### DIFF
--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -237,7 +237,8 @@ while IFS= read -r line; do
 
     PrintDebug "Started analysis of pool $line, PID $POOL_PID"
     #Extract only important information:
-    POOL_PARAMS_LIST=$($S_LSOF -p "$POOL_PID" 2>/dev/null | $S_GREP -w -e "unix" -e "TCP")
+    #Use -P to show port number instead of port name, see https://github.com/rvalitov/zabbix-php-fpm/issues/24
+    POOL_PARAMS_LIST=$($S_LSOF -P -p "$POOL_PID" 2>/dev/null | $S_GREP -w -e "unix" -e "TCP")
     FOUND_POOL=""
     while IFS= read -r pool; do
       if [[ -n $pool ]]; then


### PR DESCRIPTION
This PR fixes a problem when a pool is not discovered. It happened when all of the following conditions were met:

- the pool listens via TCP
- the pool uses a port that is defined in the system as a named port (usually in file ` /etc/services`)

In such situation the script recieved the port name instead of a number, and as a result failed to connect to it. The problem was reported here #24 

Tested in Debian 10 with PHP-FPM 7.4, with pool that listens to port 9000. To reproduce this problem a named port was added in ` /etc/services`:
```
cslistener 9000/tcp
```