### PR TITLE
Feature/timeout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
         - sudo apt-get -y purge jq
         - sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
         - sudo apt autoremove
+        - jq --version
       script: bash tests/missing.sh
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,27 @@ jobs:
   include:
     - os: linux
       dist: bionic
+      name: "Missing packages test"
+      arch: amd64
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://repo.zabbix.com/zabbix/4.0/ubuntu bionic main'
+              key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
+          packages:
+            - bc
+            - curl
+            - grep
+            - sed
+            - gawk
+            - zabbix-agent
+            - zabbix-get
+            - php-fpm
+      before_script:
+        - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
+      script: bash tests/missing.sh
+    - os: linux
+      dist: bionic
       name: "Zabbix 4.0 @ Ubuntu 18 bionic, PHP default"
       arch: amd64
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,29 @@ language: bash
 jobs:
   include:
     - os: linux
+      dist: bionic
+      name: "Missing packages test"
+      arch: amd64
+      addons:
+        apt:
+          sources:
+            - sourceline: 'deb http://repo.zabbix.com/zabbix/4.0/ubuntu bionic main'
+              key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
+          packages:
+            - bc
+            - curl
+            - grep
+            - sed
+            - gawk
+            - zabbix-agent
+      before_script:
+        - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
+        - sudo apt-get -y remove jq
+        - sudo apt-get -y remove libfcgi-bin libfcgi0ldbl
+        - sudo apt autoremove
+        - jq --version
+      script: bash tests/missing.sh
+    - os: linux
       dist: trusty
       name: "Zabbix 4.0 @ Ubuntu 14 trusty, PHP default"
       arch: amd64
@@ -51,29 +74,6 @@ jobs:
             - php-fpm
       before_script:
         - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
-    - os: linux
-      dist: bionic
-      name: "Missing packages test"
-      arch: amd64
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://repo.zabbix.com/zabbix/4.0/ubuntu bionic main'
-              key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
-          packages:
-            - bc
-            - curl
-            - grep
-            - sed
-            - gawk
-            - zabbix-agent
-      before_script:
-        - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
-        - sudo apt-get -y remove jq
-        - sudo apt-get -y remove libfcgi-bin libfcgi0ldbl
-        - sudo apt autoremove
-        - jq --version
-      script: bash tests/missing.sh
     - os: linux
       dist: bionic
       name: "Zabbix 4.0 @ Ubuntu 18 bionic, PHP default"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ jobs:
             - zabbix-get
             - php-fpm
       before_script:
+        - sudo apt-get -y purge jq
+        - sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
         - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
       script: bash tests/missing.sh
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,11 @@ jobs:
             - sed
             - gawk
             - zabbix-agent
-            - zabbix-get
-            - php-fpm
       before_script:
+        - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
         - sudo apt-get -y purge jq
         - sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
-        - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
+        - sudo apt autoremove
       script: bash tests/missing.sh
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ jobs:
             - zabbix-agent
       before_script:
         - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
-        - sudo apt-get -y purge jq
-        - sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
+        - sudo apt-get -y remove jq
+        - sudo apt-get -y remove libfcgi-bin libfcgi0ldbl
         - sudo apt autoremove
         - jq --version
       script: bash tests/missing.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ jobs:
             - zabbix-agent
       before_script:
         - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
-        - sudo apt-get -y purge jq
-        - sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
-        - sudo apt autoremove
       script: bash tests/missing.sh
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ jobs:
             - zabbix-agent
       before_script:
         - sudo curl -o /usr/local/bin/shunit2 https://raw.githubusercontent.com/kward/shunit2/master/shunit2
+        - sudo apt-get -y purge jq
+        - sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
+        - sudo apt autoremove
       script: bash tests/missing.sh
     - os: linux
       dist: bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
             - sourceline: 'deb http://repo.zabbix.com/zabbix/4.0/ubuntu bionic main'
               key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
           packages:
+            - bc
             - ca-certificates
             - curl
             - grep
@@ -37,6 +38,7 @@ jobs:
             - sourceline: 'deb http://repo.zabbix.com/zabbix/4.4/ubuntu bionic main'
               key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
           packages:
+            - bc
             - ca-certificates
             - curl
             - grep
@@ -61,6 +63,7 @@ jobs:
             - sourceline: 'deb http://repo.zabbix.com/zabbix/5.0/ubuntu bionic main'
               key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
           packages:
+            - bc
             - ca-certificates
             - curl
             - grep
@@ -86,6 +89,7 @@ jobs:
               key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
             - sourceline: 'ppa:ondrej/php'
           packages:
+            - bc
             - ca-certificates
             - curl
             - grep
@@ -115,6 +119,7 @@ jobs:
               key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
             - sourceline: 'ppa:ondrej/php'
           packages:
+            - bc
             - ca-certificates
             - curl
             - grep
@@ -144,6 +149,7 @@ jobs:
               key_url: "https://repo.zabbix.com/zabbix-official-repo.key"
             - sourceline: 'ppa:ondrej/php'
           packages:
+            - bc
             - ca-certificates
             - curl
             - grep

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Should work with any version of PHP-FPM (starting with PHP 5.3.3), Zabbix 4.0.x 
 Can work with any version of ISPConfig as long as you have a valid PHP-FPM status page configuration there.
 
 Tested with:
-- PHP 7.3, 7.4
-- Zabbix 4.0.4, 4.0.16, 4.2.5, 4.4.4
+- PHP 7.2, 7.3, 7.4
+- Zabbix 4.0.4, 4.0.16, 4.0.20, 4.2.5, 4.4.4
+- Debian 9, 10
+- CentOS 7
 - ISPConfig v.3.1.14p2

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -245,7 +245,7 @@ testZabbixDiscoverNumberOfIPPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"localhost",' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  POOLS_BY_DESIGN="$PHP_COUNT"
   assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
 }
 

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -190,7 +190,7 @@ testDiscoverScriptReturnsData() {
 }
 
 testDiscoverScriptDebug() {
-  DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "nosleep" "/php-fpm-status")
   NUMBER_OF_ERRORS=$(echo "$DATA" | grep -o -F 'Error:' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   if [[ $PHP_COUNT != $NUMBER_OF_ERRORS ]]; then
@@ -210,7 +210,15 @@ testZabbixDiscoverReturnsData() {
 }
 
 testZabbixDiscoverNumberOfStaticPools() {
-  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  OLD_DATA=""
+  DATA="1"
+
+  while
+    [[ $OLD_DATA != "$DATA" ]]
+    OLD_DATA="$DATA"
+    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  do true; done
+
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"static' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
@@ -218,7 +226,15 @@ testZabbixDiscoverNumberOfStaticPools() {
 }
 
 testZabbixDiscoverNumberOfDynamicPools() {
-  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  OLD_DATA=""
+  DATA="1"
+
+  while
+    [[ $OLD_DATA != "$DATA" ]]
+    OLD_DATA="$DATA"
+    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  do true; done
+
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"dynamic' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
@@ -226,7 +242,15 @@ testZabbixDiscoverNumberOfDynamicPools() {
 }
 
 testZabbixDiscoverNumberOfOndemandPoolsCold() {
-  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  OLD_DATA=""
+  DATA="1"
+
+  while
+    [[ $OLD_DATA != "$DATA" ]]
+    OLD_DATA="$DATA"
+    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  do true; done
+
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
   #If the pools are not started then we have 0 here:
   assertEquals "Number of pools mismatch" "0" "$NUMBER_OF_POOLS"
@@ -256,7 +280,15 @@ testZabbixDiscoverNumberOfOndemandPoolsHot() {
     fi
   done <<<"$PHP_LIST"
 
-  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  OLD_DATA=""
+  DATA="1"
+
+  while
+    [[ $OLD_DATA != "$DATA" ]]
+    OLD_DATA="$DATA"
+    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  do true; done
+
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
@@ -264,7 +296,15 @@ testZabbixDiscoverNumberOfOndemandPoolsHot() {
 }
 
 testZabbixDiscoverNumberOfIPPools() {
-  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  OLD_DATA=""
+  DATA="1"
+
+  while
+    [[ $OLD_DATA != "$DATA" ]]
+    OLD_DATA="$DATA"
+    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  do true; done
+
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"localhost",' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   POOLS_BY_DESIGN="$PHP_COUNT"
@@ -272,7 +312,15 @@ testZabbixDiscoverNumberOfIPPools() {
 }
 
 testZabbixDiscoverNumberOfPortPools() {
-  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  OLD_DATA=""
+  DATA="1"
+
+  while
+    [[ $OLD_DATA != "$DATA" ]]
+    OLD_DATA="$DATA"
+    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  do true; done
+
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"port' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -191,8 +191,9 @@ testDiscoverScriptReturnsData() {
 
 testDiscoverScriptDebug() {
   DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
-  ERRORS_LIST=$(echo "$DATA" | grep -F 'Error:')
-  assertNull "Discover script errors: $DATA" "$ERRORS_LIST"
+  NUMBER_OF_ERRORS=$(echo "$DATA" | grep -o -F 'Error:' | wc -l)
+  PHP_COUNT=$(getNumberOfPHPVersions)
+  assertEquals "Discover script errors: $DATA" "$PHP_COUNT" "$NUMBER_OF_ERRORS"
 }
 
 testZabbixDiscoverReturnsData() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -34,7 +34,7 @@ setupPool() {
   PHP_VERSION=$(echo "$POOL_DIR" | grep -oP "(\d\.\d)")
 
   #Delete all active pools except www.conf:
-  find "$POOL_DIR" -name '*.conf' -type f -not -name 'www.conf' -exec rm -rf {} \;
+  sudo find "$POOL_DIR" -name '*.conf' -type f -not -name 'www.conf' -exec rm -rf {} \;
 
   #Add status path
   sudo sed -i 's#;pm.status_path.*#pm.status_path = /php-fpm-status#' "$POOL_FILE"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -212,5 +212,15 @@ testZabbixDiscoverNumberOfPortPools() {
   assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
 }
 
+#This test should be last
+testZabbixDiscoverTimeout() {
+  #Create lots of pools
+  MAX_POOLS=100
+  MAX_PORTS=100
+  setupPools
+
+  testZabbixDiscoverReturnsData
+}
+
 # Load shUnit2.
 . shunit2

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -193,7 +193,14 @@ testDiscoverScriptDebug() {
   DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
   NUMBER_OF_ERRORS=$(echo "$DATA" | grep -o -F 'Error:' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  assertEquals "Discover script errors: $DATA" "$PHP_COUNT" "$NUMBER_OF_ERRORS"
+  if [[ $PHP_COUNT != $NUMBER_OF_ERRORS ]]; then
+    ERRORS_LIST=$(echo "$DATA" | grep -F 'Error:')
+    echo "Errors list:"
+    echo "$ERRORS_LIST"
+    echo "Full output:"
+    echo "$DATA"
+  fi
+  assertEquals "Discover script errors mismatch" "$PHP_COUNT" "$NUMBER_OF_ERRORS"
 }
 
 testZabbixDiscoverReturnsData() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -75,6 +75,7 @@ setupPool() {
   copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
 
   sudo service "php${PHP_VERSION}-fpm" restart
+  sudo systemctl status "php${PHP_VERSION}-fpm.service"
 }
 
 setupPools() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -308,18 +308,11 @@ testZabbixDiscoverNumberOfOndemandPoolsHot() {
         POOL_SOCKET="/run/php/php${PHP_VERSION}-fpm-${POOL_NAME}.sock"
 
         PHP_STATUS=$(
-          SCRIPT_NAME=$POOL_SOCKET \
-          SCRIPT_FILENAME=$POOL_SOCKET \
+          SCRIPT_NAME=$POOL_URL \
+          SCRIPT_FILENAME=$POOL_URL \
           QUERY_STRING=json \
           REQUEST_METHOD=GET \
-          sudo cgi-fcgi -bind -connect "$POOL_URL" 2>/dev/null
-        )
-        PHP_STATUS=$(
-          SCRIPT_NAME=$POOL_SOCKET \
-          SCRIPT_FILENAME=$POOL_SOCKET \
-          QUERY_STRING=json \
-          REQUEST_METHOD=GET \
-          sudo cgi-fcgi -bind -connect "$POOL_URL" 2>/dev/null
+          sudo cgi-fcgi -bind -connect "$POOL_SOCKET" 2>/dev/null
         )
         assertNotNull "Failed to connect to $POOL_SOCKET" "$PHP_STATUS"
       done

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -313,12 +313,13 @@ testDiscoverScriptRunDuration() {
   ELAPSED_TIME=$(echo "($END_TIME - $START_TIME)/1000000" | bc)
   CHECK_OK_COUNT=$(echo "$DATA" | grep -o -F "execution time OK" | wc -l)
   STOP_OK_COUNT=$(echo "$DATA" | grep -o -F "stop required" | wc -l)
+  MAX_TIME=$(echo "$ZABBIX_TIMEOUT * 1000" | bc)
 
   echo "Elapsed time $ELAPSED_TIME ms"
   echo "Success time checks: $CHECK_OK_COUNT"
   echo "Stop time checks: $STOP_OK_COUNT"
 
-  assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt 3000 ]"
+  assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt $MAX_TIME ]"
 }
 
 testZabbixDiscoverRunDuration() {
@@ -331,12 +332,13 @@ testZabbixDiscoverRunDuration() {
   ELAPSED_TIME=$(echo "($END_TIME - $START_TIME)/1000000" | bc)
   CHECK_OK_COUNT=$(echo "$DATA" | grep -o -F "execution time OK" | wc -l)
   STOP_OK_COUNT=$(echo "$DATA" | grep -o -F "stop required" | wc -l)
+  MAX_TIME=$(echo "$ZABBIX_TIMEOUT * 1000" | bc)
 
   echo "Elapsed time $ELAPSED_TIME ms"
   echo "Success time checks: $CHECK_OK_COUNT"
   echo "Stop time checks: $STOP_OK_COUNT"
 
-  assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt 3000 ]"
+  assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt $MAX_TIME ]"
 }
 
 testDiscoverScriptDoubleRun() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -226,7 +226,7 @@ testZabbixDiscoverNumberOfPortPools() {
   assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
 }
 
-#This test should be last
+#This test should be last in Zabbix tests
 testZabbixDiscoverTimeout() {
   #Create lots of pools
   MAX_POOLS=100
@@ -234,6 +234,26 @@ testZabbixDiscoverTimeout() {
   setupPools
 
   testZabbixDiscoverReturnsData
+}
+
+#################################
+#The following tests should be last, no tests of actual data should be done afterwards
+
+testMissingPackagesDiscoveryScript() {
+  sudo apt-get -y purge jq
+
+  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
+  IS_OK=$(echo "$DATA" | grep -F ' not found.')
+  assertNotNull "Discovery script didn't report error on missing utility 'jq'"
+}
+
+testMissingPackagesStatusScript() {
+  sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
+
+  PHP_POOL=$(getAnySocket)
+  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
+  IS_OK=$(echo "$DATA" | grep -F ' not found.')
+  assertNotNull "Status script didn't report error on missing utility 'cgi-fcgi'"
 }
 
 # Load shUnit2.

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -50,6 +50,15 @@ LIST_OF_SERVICES=""
 # Used for section folding in Travis CI
 SECTION_UNIQUE_ID=""
 
+#Parent directory where all cache files are located in the OS
+CACHE_ROOT="/var/cache"
+
+#Name of the private directory to store the cache files
+CACHE_DIR_NAME="zabbix-php-fpm"
+
+#Full path to directory to store cache files
+CACHE_DIRECTORY="$CACHE_ROOT/$CACHE_DIR_NAME"
+
 # ----------------------------------
 # Colors
 # ----------------------------------
@@ -518,8 +527,9 @@ oneTimeSetUp() {
 #Called before every test
 setUp() {
   #Delete all cache files
-  sudo rm -f "/etc/zabbix/php_fpm_results.cache"
-  sudo rm -f "/etc/zabbix/php_fpm_pending.cache"
+  if [[ -d "$CACHE_DIRECTORY" ]]; then
+    sudo find "$CACHE_DIRECTORY" -type f -exec rm '{}' \;
+  fi
 }
 
 #Called after every test

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -36,11 +36,6 @@ setupPool() {
   #Delete all active pools except www.conf:
   sudo find "$POOL_DIR" -name '*.conf' -type f -not -name 'www.conf' -exec rm -rf {} \;
 
-  #Add status path
-  sudo sed -i 's#;pm.status_path.*#pm.status_path = /php-fpm-status#' "$POOL_FILE"
-  #Set pool manager
-  sudo sed -i 's#pm = dynamic#pm = static#' "$POOL_FILE"
-
   #Create new socket pools
   for ((c = 1; c <= MAX_POOLS; c++)); do
     POOL_NAME="static$c"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -218,7 +218,7 @@ testDiscoverScriptSleep() {
   echo "Success time checks: $CHECK_OK_COUNT"
   echo "Stop time checks: $STOP_OK_COUNT"
 
-  if [[ $CHECK_OK_COUNT -lt 1 ]] || [[ $STOP_OK_COUNT -lt 1 ]];then
+  if [[ $CHECK_OK_COUNT -lt 1 ]] || [[ $STOP_OK_COUNT -lt 1 ]]; then
     echo "$DATA"
   fi
   assertTrue "No success time checks detected" "[ $CHECK_OK_COUNT -gt 0 ]"
@@ -365,12 +365,16 @@ testZabbixDiscoverNumberOfPortPools() {
 }
 
 #This test should be last in Zabbix tests
-testZabbixDiscoverTimeout() {
+testDiscoverScriptTimeout() {
   #Create lots of pools
   MAX_POOLS=20
   MAX_PORTS=20
   setupPools
 
+  testDiscoverScriptReturnsData
+}
+
+testZabbixDiscoverTimeout() {
   testZabbixDiscoverReturnsData
 }
 

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -330,13 +330,9 @@ testZabbixDiscoverRunDuration() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   END_TIME=$(date +%s%N)
   ELAPSED_TIME=$(echo "($END_TIME - $START_TIME)/1000000" | bc)
-  CHECK_OK_COUNT=$(echo "$DATA" | grep -o -F "execution time OK" | wc -l)
-  STOP_OK_COUNT=$(echo "$DATA" | grep -o -F "stop required" | wc -l)
   MAX_TIME=$(echo "$ZABBIX_TIMEOUT * 1000" | bc)
 
   echo "Elapsed time $ELAPSED_TIME ms"
-  echo "Success time checks: $CHECK_OK_COUNT"
-  echo "Stop time checks: $STOP_OK_COUNT"
 
   assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt $MAX_TIME ]"
 }
@@ -516,11 +512,19 @@ testZabbixDiscoverManyPools() {
 }
 
 testDiscoverScriptManyPoolsRunDuration() {
-  testDiscoverScriptRunDuration
+  MAX_RUNS=5
+  for ((c = 1; c <= MAX_RUNS; c++)); do
+    echo "Run #$c..."
+    testDiscoverScriptRunDuration
+  done
 }
 
 testZabbixDiscoverManyPoolsRunDuration() {
-  testZabbixDiscoverRunDuration
+  MAX_RUNS=5
+  for ((c = 1; c <= MAX_RUNS; c++)); do
+    echo "Run #$c..."
+    testZabbixDiscoverRunDuration
+  done
 }
 
 # Load shUnit2.

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -158,7 +158,7 @@ testStatusScriptSocket() {
   PHP_POOL=$(getAnySocket)
 
   #Make the test:
-  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
   echo "Success test of $PHP_POOL"
@@ -169,7 +169,7 @@ testStatusScriptPort() {
   PHP_POOL="127.0.0.1:$PHP_PORT"
 
   #Make the test:
-  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
   echo "Success test of $PHP_POOL"
@@ -195,13 +195,13 @@ testZabbixStatusPort() {
 }
 
 testDiscoverScriptReturnsData() {
-  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"data":[{"{#POOLNAME}"')
   assertNotNull "Discover script failed: $DATA" "$IS_OK"
 }
 
 testDiscoverScriptDebug() {
-  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
   ERRORS_LIST=$(echo "$DATA" | grep -F 'Error:')
   assertNull "Discover script errors: $DATA" "$ERRORS_LIST"
 }

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -460,12 +460,14 @@ function actionService() {
   local SERVICE_NAME=$1
   local SERVICE_ACTION=$2
   local SERVICE_INFO
+  sleep 3
   SERVICE_INFO=$(sudo service "$SERVICE_NAME" $SERVICE_ACTION)
   STATUS=$?
   if [[ "$STATUS" -ne 0 ]]; then
     printRed "Failed to $SERVICE_ACTION service '$SERVICE_NAME':"
     echo "$SERVICE_INFO"
   fi
+  sleep 3
 }
 
 function restartService() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -111,6 +111,17 @@ setupPool() {
 
 setupPools() {
   PHP_LIST=$(sudo find /etc/php/ -name 'www.conf' -type f)
+
+  #First we need to stop all PHP-FPM
+  while IFS= read -r pool; do
+    if [[ -n $pool ]]; then
+      POOL_DIR=$(dirname "$pool")
+      PHP_VERSION=$(echo "$POOL_DIR" | grep -oP "(\d\.\d)")
+      sudo service "php${PHP_VERSION}-fpm" stop
+    fi
+  done <<<"$PHP_LIST"
+
+  #Now we reconfigure them and restart
   while IFS= read -r pool; do
     if [[ -n $pool ]]; then
       setupPool "$pool"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -131,6 +131,13 @@ oneTimeSetUp() {
   echo "All done, starting tests..."
 }
 
+#Called before every test
+setUp() {
+  #Delete all cache files
+  sudo rm -rf "/etc/zabbix/*.cache"
+}
+
+#Called after every test
 tearDown() {
   restoreUserParameters
   sleep 2

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -78,8 +78,11 @@ setupPool() {
   POOL_SOCKET="127.0.0.1:$POOL_PORT"
   copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
 
+  sudo ls -l "$POOL_DIR"
   sudo service "php${PHP_VERSION}-fpm" restart
+  sleep 3
   sudo systemctl -l status "php${PHP_VERSION}-fpm.service"
+  sleep 2
 }
 
 setupPools() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -78,9 +78,12 @@ setupPool() {
   POOL_SOCKET="127.0.0.1:$POOL_PORT"
   copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
 
+  echo "List of configured PHP$PHP_VERSION pools:"
   sudo ls -l "$POOL_DIR"
   sudo service "php${PHP_VERSION}-fpm" restart
   sleep 3
+
+  echo "List of running PHP$PHP_VERSION pools:"
   sudo systemctl -l status "php${PHP_VERSION}-fpm.service"
   sleep 2
 }
@@ -134,7 +137,8 @@ oneTimeSetUp() {
 #Called before every test
 setUp() {
   #Delete all cache files
-  sudo rm -rf "/etc/zabbix/*.cache"
+  sudo rm -f "/etc/zabbix/php_fpm_results.cache"
+  sudo rm -f "/etc/zabbix/php_fpm_pending.cache"
 }
 
 #Called after every test
@@ -257,6 +261,7 @@ function restoreUserParameters() {
 function AddSleepToConfig() {
   PARAMS_FILE=$(getUserParameters)
   sudo sed -i 's#.*zabbix_php_fpm_discovery.*#UserParameter=php-fpm.discover[*],sudo /etc/zabbix/zabbix_php_fpm_discovery.sh sleep $1#' "$PARAMS_FILE"
+  echo "New UserParameter file:"
   sudo cat "$PARAMS_FILE"
   sudo service zabbix-agent restart
   sleep 2

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -75,7 +75,7 @@ setupPool() {
   copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
 
   sudo service "php${PHP_VERSION}-fpm" restart
-  sudo systemctl status "php${PHP_VERSION}-fpm.service"
+  sudo systemctl -l status "php${PHP_VERSION}-fpm.service"
 }
 
 setupPools() {
@@ -215,10 +215,14 @@ testDiscoverScriptSleep() {
   CHECK_OK_COUNT=$(echo "$DATA" | grep -o -F "execution time OK" | wc -l)
   STOP_OK_COUNT=$(echo "$DATA" | grep -o -F "stop required" | wc -l)
 
-  assertTrue "No success time checks detected" "[ $CHECK_OK_COUNT -gt 0 ]"
   echo "Success time checks: $CHECK_OK_COUNT"
-  assertTrue "No success stop checks detected" "[ $STOP_OK_COUNT -gt 0 ]"
   echo "Stop time checks: $STOP_OK_COUNT"
+
+  if [[ $CHECK_OK_COUNT -lt 1 ]] || [[ $STOP_OK_COUNT -lt 1 ]];then
+    echo "$DATA"
+  fi
+  assertTrue "No success time checks detected" "[ $CHECK_OK_COUNT -gt 0 ]"
+  assertTrue "No success stop checks detected" "[ $STOP_OK_COUNT -gt 0 ]"
 }
 
 testDiscoverScriptDoubleRun() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -3,15 +3,115 @@
 #https://github.com/rvalitov/zabbix-php-fpm
 #This script is used for testing
 
+################################### START OF CONFIGURATION CONSTANTS
+
+# Number of pools, created for each ondemand, static and dynamic sockets.
 MAX_POOLS=3
+
+# Number of port based pools created for each PHP version
 MAX_PORTS=3
+
+# Starting port number for port based PHP pools
 MIN_PORT=49001
+
+# Maximum number of ports per PHP version, this value is used to define the available port range.
 MAX_PORTS_COUNT=100
-TEST_SOCKET=""
+
+# Timeout in seconds that we put in the option "pm.process_idle_timeout" of configuration of ondemand PHP pools.
 ONDEMAND_TIMEOUT=60
+
+# Timeout in seconds that we put in the configuration of Zabbix agent
 ZABBIX_TIMEOUT=20
+
+# Maximum iterations to perform during sequential scans of pools, when the operation is time-consuming and requires
+# multiple calls to the discovery script.
+# This value should be big enough to be able to get information about all pools in the system.
+# It allows to exit from indefinite check loops.
+MAX_CHECKS=150
+
+################################### END OF CONFIGURATION CONSTANTS
+
+# A random socket used for tests, this variable is defined when PHP pools are created
+TEST_SOCKET=""
+
+# The directory where the PHP socket files are located, for example, /var/run or /run.
+# This variable is used as cache, because it may be impossible to detect it when we start and stop the PHP-FPM.
+# Don't use this variable directly. Use function getRunPHPDirectory
 PHP_SOCKET_DIR=""
+
+# The directory where the PHP configuration files are located, for example, /etc/php or /etc/php5.
+# This variable is used as cache. So, don't use this variable directly. Use function getEtcPHPDirectory
 PHP_ETC_DIR=""
+
+# List of all services in the system.
+# This variable is used as cache. So, don't use this variable directly. Use function getPHPServiceName
+LIST_OF_SERVICES=""
+
+# Used for section folding in Travis CI
+SECTION_UNIQUE_ID=""
+
+# ----------------------------------
+# Colors
+# ----------------------------------
+NOCOLOR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+ORANGE='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+LIGHTGRAY='\033[0;37m'
+DARKGRAY='\033[1;30m'
+LIGHTRED='\033[1;31m'
+LIGHTGREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+LIGHTBLUE='\033[1;34m'
+LIGHTPURPLE='\033[1;35m'
+LIGHTCYAN='\033[1;36m'
+WHITE='\033[1;37m'
+
+function printYellow() {
+  local info=$1
+  echo -e "${YELLOW}$info${NOCOLOR}"
+}
+
+function printRed() {
+  local info=$1
+  echo -e "${RED}$info${NOCOLOR}"
+}
+
+function printGreen() {
+  local info=$1
+  echo -e "${LIGHTGREEN}$info${NOCOLOR}"
+}
+
+function printSuccess() {
+  local name=$1
+  printGreen "✓ OK: test '$name' passed"
+}
+
+function printDebug() {
+  local info=$1
+  echo -e "${DARKGRAY}$info${NOCOLOR}"
+}
+
+function printAction() {
+  local info=$1
+  echo -e "${LIGHTBLUE}$info${NOCOLOR}"
+}
+
+function travis_fold_start() {
+  local name=$1
+  local info=$2
+  local CURRENT_TIMING
+  CURRENT_TIMING=$(date +%s%3N)
+  SECTION_UNIQUE_ID="$name.$CURRENT_TIMING"
+  echo -e "travis_fold:start:${SECTION_UNIQUE_ID}\033[33;1m${info}\033[0m"
+}
+
+function travis_fold_end() {
+  echo -e "\ntravis_fold:end:${SECTION_UNIQUE_ID}\r"
+}
 
 function getUserParameters() {
   sudo find /etc/zabbix/ -name 'userparameter_php_fpm.conf' -type f 2>/dev/null | sort | head -n1
@@ -19,16 +119,17 @@ function getUserParameters() {
 
 function restoreUserParameters() {
   PARAMS_FILE=$(getUserParameters)
-  sudo rm -f $PARAMS_FILE
+  sudo rm -f "$PARAMS_FILE"
   sudo cp "$TRAVIS_BUILD_DIR/zabbix/userparameter_php_fpm.conf" "$(sudo find /etc/zabbix/ -name 'zabbix_agentd*.d' -type d 2>/dev/null | sort | head -n1)"
 }
 
 function AddSleepToConfig() {
   PARAMS_FILE=$(getUserParameters)
   sudo sed -i 's#.*zabbix_php_fpm_discovery.*#UserParameter=php-fpm.discover[*],sudo /etc/zabbix/zabbix_php_fpm_discovery.sh sleep $1#' "$PARAMS_FILE"
-  echo "New UserParameter file:"
+  travis_fold_start "AddSleepToConfig" "ⓘ New UserParameter file"
   sudo cat "$PARAMS_FILE"
-  sudo service zabbix-agent restart
+  travis_fold_end
+  restartService "zabbix-agent"
   sleep 2
 }
 
@@ -39,6 +140,10 @@ function getPHPVersion() {
     PHP_VERSION=$(echo "$TEST_STRING" | grep -oP "php(\d)" | grep -oP "(\d)")
   fi
   echo "$PHP_VERSION"
+  if [[ -z "$PHP_VERSION" ]]; then
+    return 1
+  fi
+  return 0
 }
 
 function getEtcPHPDirectory() {
@@ -54,10 +159,14 @@ function getEtcPHPDirectory() {
   for PHP_TEST_DIR in "${LIST_OF_DIRS[@]}"; do
     if [[ -d "$PHP_TEST_DIR" ]]; then
       PHP_ETC_DIR=$PHP_TEST_DIR
-      echo "$PHP_ETC_DIR"
-      return 0
+      break
     fi
   done
+
+  if [[ -n "$PHP_ETC_DIR" ]]; then
+    echo "$PHP_ETC_DIR"
+    return 0
+  fi
 
   return 1
 }
@@ -73,13 +182,37 @@ function getRunPHPDirectory() {
     "/var/run/"
   )
   for PHP_TEST_DIR in "${LIST_OF_DIRS[@]}"; do
-    RESULT_DIR=$(find "$PHP_TEST_DIR" -name 'php*-fpm.sock' -type s -exec dirname {} \; 2>/dev/null | sort | head -n1)
+    RESULT_DIR=$(sudo find "$PHP_TEST_DIR" -name 'php*-fpm.sock' -type s -exec dirname {} \; 2>/dev/null | sort | head -n1)
     if [[ -d "$RESULT_DIR" ]]; then
       PHP_SOCKET_DIR="$RESULT_DIR/"
-      echo "$PHP_SOCKET_DIR"
-      return 0
+      break
     fi
   done
+
+  if [[ -z "$PHP_SOCKET_DIR" ]]; then
+    #Try to parse the location from default config
+    PHP_DIR=$(getEtcPHPDirectory)
+    EXIT_CODE=$?
+    assertEquals "Failed to find PHP configuration directory" "0" "$EXIT_CODE"
+    assertTrue "PHP configuration directory '$PHP_DIR' is not a directory" "[ -d $PHP_DIR ]"
+
+    DEFAULT_CONF=$(sudo find "$PHP_DIR" -name "www.conf" -type f | uniq | head -n1)
+    assertTrue "Failed to find default www.conf file inside '$PHP_DIR'" "[ -n $DEFAULT_CONF ]"
+
+    DEFAULT_SOCKET=$(sudo grep -Po 'listen = (.+)' "$DEFAULT_CONF" | cut -d '=' -f2 | sed -e 's/^[ \t]*//')
+    assertTrue "Failed to extract socket information from '$DEFAULT_CONF'" "[ -n $DEFAULT_SOCKET ]"
+
+    RESULT_DIR=$(dirname "$DEFAULT_SOCKET")
+    assertTrue "Directory '$RESULT_DIR' does not exist" "[ -d $RESULT_DIR ]"
+    if [[ -d "$RESULT_DIR" ]]; then
+      PHP_SOCKET_DIR="$RESULT_DIR/"
+    fi
+  fi
+
+  if [[ -n "$PHP_SOCKET_DIR" ]]; then
+    echo "$PHP_SOCKET_DIR"
+    return 0
+  fi
 
   return 1
 }
@@ -91,6 +224,7 @@ copyPool() {
   POOL_TYPE=$4
   POOL_DIR=$(dirname "${ORIGINAL_FILE}")
   PHP_VERSION=$(getPHPVersion "$POOL_DIR")
+  assertNotNull "Failed to detect PHP version from string '$POOL_DIR'" "$PHP_VERSION"
 
   NEW_POOL_FILE="$POOL_DIR/${POOL_NAME}.conf"
   sudo cp "$ORIGINAL_FILE" "$NEW_POOL_FILE"
@@ -109,16 +243,42 @@ copyPool() {
   fi
 }
 
+getPHPServiceName() {
+  PHP_VERSION=$1
+  if [[ -z "$LIST_OF_SERVICES" ]]; then
+    LIST_OF_SERVICES=$(sudo service --status-all 2>/dev/null | sort)
+  fi
+
+  LIST_OF_NAMES=(
+    "php${PHP_VERSION}-fpm"
+    "php-fpm"
+  )
+
+  for SERVICE_NAME in "${LIST_OF_NAMES[@]}"; do
+    RESULT=$(echo "$LIST_OF_SERVICES" | grep -F "$SERVICE_NAME")
+    if [[ -n "$RESULT" ]]; then
+      echo "$SERVICE_NAME"
+      return 0
+    fi
+  done
+  return 1
+}
+
 setupPool() {
   POOL_FILE=$1
   POOL_DIR=$(dirname "${POOL_FILE}")
   PHP_VERSION=$(getPHPVersion "$POOL_DIR")
+  assertNotNull "Failed to detect PHP version from string '$POOL_DIR'" "$PHP_VERSION"
 
   PHP_RUN_DIR=$(getRunPHPDirectory)
   EXIT_CODE=$?
   assertEquals "Failed to find PHP run directory" "0" "$EXIT_CODE"
+  assertTrue "PHP run directory '$PHP_RUN_DIR' is not a directory" "[ -d $PHP_RUN_DIR ]"
 
   PHP_DIR=$(getEtcPHPDirectory)
+  EXIT_CODE=$?
+  assertEquals "Failed to find PHP configuration directory" "0" "$EXIT_CODE"
+  assertTrue "PHP configuration directory '$PHP_DIR' is not a directory" "[ -d $PHP_DIR ]"
 
   #Delete all active pools except www.conf:
   sudo find "$POOL_DIR" -name '*.conf' -type f -not -name 'www.conf' -exec rm -rf {} \;
@@ -145,7 +305,7 @@ setupPool() {
     copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "ondemand"
   done
 
-  PHP_SERIAL_ID=$(find "$PHP_DIR" -maxdepth 1 -mindepth 1 -type d | sort | grep -n -F "$PHP_VERSION" | head -n1 | cut -d : -f 1)
+  PHP_SERIAL_ID=$(sudo find "$PHP_DIR" -maxdepth 1 -mindepth 1 -type d | sort | grep -n -F "$PHP_VERSION" | head -n1 | cut -d : -f 1)
   #Create TCP port based pools
   #Division on 1 is required to convert from float to integer
   START_PORT=$(echo "($MIN_PORT + $PHP_SERIAL_ID * $MAX_PORTS_COUNT + 1)/1" | bc)
@@ -165,31 +325,51 @@ setupPool() {
   assertNull "Port $POOL_PORT is busy" "$PORT_IS_BUSY"
   copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
 
-  echo "List of configured PHP$PHP_VERSION pools:"
+  travis_fold_start "list_PHP$PHP_VERSION" "ⓘ List of configured PHP$PHP_VERSION pools"
   sudo ls -l "$POOL_DIR"
-  sudo service "php${PHP_VERSION}-fpm" restart
+  travis_fold_end
+
+  SERVICE_NAME=$(getPHPServiceName "$PHP_VERSION")
+  assertNotNull "Failed to detect service name for PHP${PHP_VERSION}" "$SERVICE_NAME"
+  printAction "Restarting service $SERVICE_NAME..."
+  restartService "$SERVICE_NAME"
   sleep 3
 
-  echo "List of running PHP$PHP_VERSION pools:"
-  sudo systemctl -l status "php${PHP_VERSION}-fpm.service"
+  travis_fold_start "running_PHP$PHP_VERSION" "ⓘ List of running PHP$PHP_VERSION pools"
+  E_SYSTEM_CONTROL=$(type -P systemctl)
+  if [[ -x "$E_SYSTEM_CONTROL" ]]; then
+    sudo systemctl -l status "$SERVICE_NAME.service"
+  else
+    sudo initctl list | grep -F "$SERVICE_NAME"
+  fi
+  travis_fold_end
   sleep 2
 }
 
 setupPools() {
   PHP_DIR=$(getEtcPHPDirectory)
   EXIT_CODE=$?
-  assertEquals "Failed to find PHP directory" "0" "$EXIT_CODE"
+  assertEquals "Failed to find PHP configuration directory" "0" "$EXIT_CODE"
+  assertTrue "PHP configuration directory '$PHP_DIR' is not a directory" "[ -d $PHP_DIR ]"
+
   PHP_LIST=$(sudo find "$PHP_DIR" -name 'www.conf' -type f)
 
   #Call to detect and cache PHP run directory, we need to call it before we stop all PHP-FPM
-  getRunPHPDirectory
+  PHP_RUN_DIR=$(getRunPHPDirectory)
+  EXIT_CODE=$?
+  assertEquals "Failed to find PHP run directory" "0" "$EXIT_CODE"
+  assertTrue "PHP run directory '$PHP_RUN_DIR' is not a directory" "[ -d $PHP_RUN_DIR ]"
 
   #First we need to stop all PHP-FPM
   while IFS= read -r pool; do
     if [[ -n $pool ]]; then
       POOL_DIR=$(dirname "$pool")
       PHP_VERSION=$(getPHPVersion "$POOL_DIR")
-      sudo service "php${PHP_VERSION}-fpm" stop
+      assertNotNull "Failed to detect PHP version from string '$POOL_DIR'" "$PHP_VERSION"
+      SERVICE_NAME=$(getPHPServiceName "$PHP_VERSION")
+      assertNotNull "Failed to detect service name for PHP${PHP_VERSION}" "$SERVICE_NAME"
+      printAction "Stopping service $SERVICE_NAME..."
+      stopService "$SERVICE_NAME"
     fi
   done <<<"$PHP_LIST"
 
@@ -204,20 +384,23 @@ setupPools() {
 getNumberOfPHPVersions() {
   PHP_DIR=$(getEtcPHPDirectory)
   EXIT_CODE=$?
-  assertEquals "Failed to find PHP directory" "0" "$EXIT_CODE"
+  assertEquals "Failed to find PHP configuration directory" "0" "$EXIT_CODE"
+  assertTrue "PHP configuration directory '$PHP_DIR' is not a directory" "[ -d $PHP_DIR ]"
 
-  PHP_COUNT=$(find "$PHP_DIR" -name 'www.conf' -type f | wc -l)
+  PHP_COUNT=$(sudo find "$PHP_DIR" -name 'www.conf' -type f | wc -l)
   echo "$PHP_COUNT"
 }
 
 function startOndemandPoolsCache() {
   PHP_DIR=$(getEtcPHPDirectory)
   EXIT_CODE=$?
-  assertEquals "Failed to find PHP directory" "0" "$EXIT_CODE"
+  assertEquals "Failed to find PHP configuration directory" "0" "$EXIT_CODE"
+  assertTrue "PHP configuration directory '$PHP_DIR' is not a directory" "[ -d $PHP_DIR ]"
 
   PHP_RUN_DIR=$(getRunPHPDirectory)
   EXIT_CODE=$?
   assertEquals "Failed to find PHP run directory" "0" "$EXIT_CODE"
+  assertTrue "PHP run directory '$PHP_RUN_DIR' is not a directory" "[ -d $PHP_RUN_DIR ]"
 
   # We must start all the pools
   POOL_URL="/php-fpm-status"
@@ -227,6 +410,7 @@ function startOndemandPoolsCache() {
     if [[ -n $pool ]]; then
       POOL_DIR=$(dirname "$pool")
       PHP_VERSION=$(getPHPVersion "$POOL_DIR")
+      assertNotNull "Failed to detect PHP version from string '$POOL_DIR'" "$PHP_VERSION"
 
       for ((c = 1; c <= MAX_POOLS; c++)); do
         POOL_NAME="ondemand$c"
@@ -248,18 +432,20 @@ function startOndemandPoolsCache() {
 getAnySocket() {
   PHP_DIR=$(getEtcPHPDirectory)
   EXIT_CODE=$?
-  assertEquals "Failed to find PHP directory" "0" "$EXIT_CODE"
+  assertEquals "Failed to find PHP configuration directory" "0" "$EXIT_CODE"
+  assertTrue "PHP configuration directory '$PHP_DIR' is not a directory" "[ -d $PHP_DIR ]"
 
   PHP_RUN_DIR=$(getRunPHPDirectory)
   EXIT_CODE=$?
   assertEquals "Failed to find PHP run directory" "0" "$EXIT_CODE"
+  assertTrue "PHP run directory '$PHP_RUN_DIR' is not a directory" "[ -d $PHP_RUN_DIR ]"
 
   #Get any socket of PHP-FPM:
-  PHP_FIRST=$(find "$PHP_DIR" -name 'www.conf' -type f | sort | head -n1)
+  PHP_FIRST=$(sudo find "$PHP_DIR" -name 'www.conf' -type f | sort | head -n1)
   assertNotNull "Failed to get PHP conf" "$PHP_FIRST"
   PHP_VERSION=$(getPHPVersion "$PHP_FIRST")
-  assertNotNull "Failed to get PHP version for $PHP_FIRST" "$PHP_VERSION"
-  PHP_POOL=$(find "$PHP_RUN_DIR" -name "php${PHP_VERSION}*.sock" -type s 2>/dev/null | sort | head -n1)
+  assertNotNull "Failed to detect PHP version from string '$PHP_FIRST'" "$PHP_VERSION"
+  PHP_POOL=$(sudo find "$PHP_RUN_DIR" -name "php${PHP_VERSION}*.sock" -type s 2>/dev/null | sort | head -n1)
   assertNotNull "Failed to get PHP${PHP_VERSION} socket" "$PHP_POOL"
   echo "$PHP_POOL"
 }
@@ -270,31 +456,61 @@ getAnyPort() {
   echo "$PHP_PORT"
 }
 
+function actionService() {
+  local SERVICE_NAME=$1
+  local SERVICE_ACTION=$2
+  local SERVICE_INFO
+  SERVICE_INFO=$(sudo service "$SERVICE_NAME" $SERVICE_ACTION)
+  STATUS=$?
+  if [[ "$STATUS" -ne 0 ]]; then
+    printRed "Failed to $SERVICE_ACTION service '$SERVICE_NAME':"
+    echo "$SERVICE_INFO"
+  fi
+}
+
+function restartService() {
+  local SERVICE_NAME=$1
+  actionService "$SERVICE_NAME" "restart"
+}
+
+function stopService() {
+  local SERVICE_NAME=$1
+  actionService "$SERVICE_NAME" "stop"
+}
+
 oneTimeSetUp() {
-  echo "Started job $TRAVIS_JOB_NAME"
-  echo "Host info:"
+  printAction "Started job $TRAVIS_JOB_NAME"
+
+  travis_fold_start "host_info" "ⓘ Host information"
   nslookup localhost
   sudo ifconfig
   sudo cat /etc/hosts
-  echo "Copying Zabbix files..."
+  travis_fold_end
+
+  printAction "Copying Zabbix files..."
   #Install files:
   sudo cp "$TRAVIS_BUILD_DIR/zabbix/zabbix_php_fpm_discovery.sh" "/etc/zabbix"
   sudo cp "$TRAVIS_BUILD_DIR/zabbix/zabbix_php_fpm_status.sh" "/etc/zabbix"
-  sudo cp "$TRAVIS_BUILD_DIR/zabbix/userparameter_php_fpm.conf" "$(find /etc/zabbix/ -name 'zabbix_agentd*.d' -type d | sort | head -n1)"
+  sudo cp "$TRAVIS_BUILD_DIR/zabbix/userparameter_php_fpm.conf" "$(sudo find /etc/zabbix/ -name 'zabbix_agentd*.d' -type d | sort | head -n1)"
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_discovery.sh
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_status.sh
 
   #Configure Zabbix:
   echo 'zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_php_fpm_discovery.sh,/etc/zabbix/zabbix_php_fpm_status.sh' | sudo EDITOR='tee -a' visudo
   sudo sed -i "s#.* Timeout=.*#Timeout = $ZABBIX_TIMEOUT#" "/etc/zabbix/zabbix_agentd.conf"
-  sudo service zabbix-agent restart
 
-  echo "Setup PHP-FPM..."
+  travis_fold_start "zabbix_agent" "ⓘ Zabbix agent configuration"
+  sudo cat "/etc/zabbix/zabbix_agentd.conf"
+  travis_fold_end
+
+  restartService "zabbix-agent"
+
+  printAction "Setup PHP-FPM..."
 
   #Setup PHP-FPM pools:
   setupPools
 
-  echo "All done, starting tests..."
+  printAction "All done, starting tests..."
 }
 
 #Called before every test
@@ -308,13 +524,14 @@ setUp() {
 tearDown() {
   restoreUserParameters
   sleep 2
-  sudo service zabbix-agent restart
+  restartService "zabbix-agent"
   sleep 2
 }
 
 testZabbixGetInstalled() {
   ZABBIX_GET=$(type -P zabbix_get)
   assertNotNull "Utility zabbix-get not installed" "$ZABBIX_GET"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixAgentVersion() {
@@ -322,6 +539,7 @@ testZabbixAgentVersion() {
   REQUESTED_VERSION=$(echo "$TRAVIS_JOB_NAME" | grep -i -F "zabbix" | head -n1 | cut -d "@" -f1 | cut -d " " -f2)
   INSTALLED_VERSION=$(zabbix_agentd -V | grep -F "zabbix" | head -n1 | rev | cut -d " " -f1 | rev | cut -d "." -f1,2)
   assertSame "Requested version $REQUESTED_VERSION and installed version $INSTALLED_VERSION of Zabbix agent do not match" "$REQUESTED_VERSION" "$INSTALLED_VERSION"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixGetVersion() {
@@ -329,11 +547,13 @@ testZabbixGetVersion() {
   REQUESTED_VERSION=$(echo "$TRAVIS_JOB_NAME" | grep -i -F "zabbix" | head -n1 | cut -d "@" -f1 | cut -d " " -f2)
   INSTALLED_VERSION=$(zabbix_get -V | grep -F "zabbix" | head -n1 | rev | cut -d " " -f1 | rev | cut -d "." -f1,2)
   assertSame "Requested version $REQUESTED_VERSION and installed version $INSTALLED_VERSION of zabbix_get do not match" "$REQUESTED_VERSION" "$INSTALLED_VERSION"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testPHPIsRunning() {
   IS_OK=$(sudo ps ax | grep -F "php-fpm: pool " | grep -F -v "grep" | head -n1)
   assertNotNull "No running PHP-FPM instances found" "$IS_OK"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testStatusScriptSocket() {
@@ -341,7 +561,8 @@ testStatusScriptSocket() {
   DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_status.sh" "$TEST_SOCKET" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $TEST_SOCKET: $DATA" "$IS_OK"
-  echo "Success test of $TEST_SOCKET"
+  printGreen "Success test of $TEST_SOCKET"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testStatusScriptPort() {
@@ -352,14 +573,16 @@ testStatusScriptPort() {
   DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
-  echo "Success test of $PHP_POOL"
+  printGreen "Success test of $PHP_POOL"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixStatusSocket() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.status["$TEST_SOCKET","/php-fpm-status"])
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
-  echo "Success test of $PHP_POOL"
+  printGreen "Success test of $PHP_POOL"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixStatusPort() {
@@ -369,13 +592,15 @@ testZabbixStatusPort() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.status["$PHP_POOL","/php-fpm-status"])
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
-  echo "Success test of $PHP_POOL"
+  printGreen "Success test of $PHP_POOL"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testDiscoverScriptReturnsData() {
   DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"data":[{"{#POOLNAME}"')
   assertNotNull "Discover script failed: $DATA" "$IS_OK"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testDiscoverScriptDebug() {
@@ -384,18 +609,21 @@ testDiscoverScriptDebug() {
   PHP_COUNT=$(getNumberOfPHPVersions)
   if [[ $PHP_COUNT != "$NUMBER_OF_ERRORS" ]]; then
     ERRORS_LIST=$(echo "$DATA" | grep -F 'Error:')
-    echo "Errors list:"
-    echo "$ERRORS_LIST"
-    echo "Full output:"
+    printYellow "Errors list:"
+    printYellow "$ERRORS_LIST"
+    travis_fold_start "testDiscoverScriptDebug_full" "ⓘ Full output"
     echo "$DATA"
+    travis_fold_end
   fi
   assertEquals "Discover script errors mismatch" "$PHP_COUNT" "$NUMBER_OF_ERRORS"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverReturnsData() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   IS_OK=$(echo "$DATA" | grep -F '{"data":[{"{#POOLNAME}"')
   assertNotNull "Discover script failed: $DATA" "$IS_OK"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testDiscoverScriptSleep() {
@@ -403,14 +631,17 @@ testDiscoverScriptSleep() {
   CHECK_OK_COUNT=$(echo "$DATA" | grep -o -F "execution time OK" | wc -l)
   STOP_OK_COUNT=$(echo "$DATA" | grep -o -F "stop required" | wc -l)
 
-  echo "Success time checks: $CHECK_OK_COUNT"
-  echo "Stop time checks: $STOP_OK_COUNT"
+  printYellow "Success time checks: $CHECK_OK_COUNT"
+  printYellow "Stop time checks: $STOP_OK_COUNT"
 
   if [[ $CHECK_OK_COUNT -lt 1 ]] || [[ $STOP_OK_COUNT -lt 1 ]]; then
+    travis_fold_start "ScriptSleep" "ⓘ Zabbix response"
     echo "$DATA"
+    travis_fold_end
   fi
-  assertTrue "No success time checks detected" "[ $CHECK_OK_COUNT -gt 0 ]"
+  assertTrue "No success time checks detected" "[ $CHECK_OK_COUNT -gt 0 ] || [ $STOP_OK_COUNT -eq 1 ]"
   assertTrue "No success stop checks detected" "[ $STOP_OK_COUNT -gt 0 ]"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverSleep() {
@@ -418,6 +649,7 @@ testZabbixDiscoverSleep() {
   AddSleepToConfig
 
   testZabbixDiscoverReturnsData
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testDiscoverScriptRunDuration() {
@@ -429,11 +661,12 @@ testDiscoverScriptRunDuration() {
   STOP_OK_COUNT=$(echo "$DATA" | grep -o -F "stop required" | wc -l)
   MAX_TIME=$(echo "$ZABBIX_TIMEOUT * 1000" | bc)
 
-  echo "Elapsed time $ELAPSED_TIME ms"
-  echo "Success time checks: $CHECK_OK_COUNT"
-  echo "Stop time checks: $STOP_OK_COUNT"
+  printYellow "Elapsed time $ELAPSED_TIME ms"
+  printYellow "Success time checks: $CHECK_OK_COUNT"
+  printYellow "Stop time checks: $STOP_OK_COUNT"
 
   assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt $MAX_TIME ]"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverRunDuration() {
@@ -446,16 +679,18 @@ testZabbixDiscoverRunDuration() {
   ELAPSED_TIME=$(echo "($END_TIME - $START_TIME)/1000000" | bc)
   MAX_TIME=$(echo "$ZABBIX_TIMEOUT * 1000" | bc)
 
-  echo "Elapsed time $ELAPSED_TIME ms"
+  printYellow "Elapsed time $ELAPSED_TIME ms"
 
   assertTrue "The script worked for too long" "[ $ELAPSED_TIME -lt $MAX_TIME ]"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testDiscoverScriptDoubleRun() {
   DATA_FIRST=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "sleep" "/php-fpm-status")
   DATA_SECOND=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "sleep" "/php-fpm-status")
 
-  assertNotEquals "Multiple discovery routines provide the same results" "$DATA_FIRST" "$DATA_SECOND"
+  assertNotEquals "Multiple discovery routines provide the same results: $DATA_FIRST" "$DATA_FIRST" "$DATA_SECOND"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverDoubleRun() {
@@ -465,150 +700,138 @@ testZabbixDiscoverDoubleRun() {
   DATA_FIRST=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   DATA_SECOND=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
 
-  assertNotEquals "Multiple discovery routines provide the same results" "$DATA_FIRST" "$DATA_SECOND"
+  assertNotEquals "Multiple discovery routines provide the same results: $DATA_FIRST" "$DATA_FIRST" "$DATA_SECOND"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 function discoverAllZabbix() {
   DATA_OLD=$1
   DATA_COUNT=$2
-  MAX_CHECKS=150
 
   if [[ -z $DATA_COUNT ]]; then
     DATA_COUNT=0
   fi
 
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
-  if [[ "$DATA_OLD" == "$DATA" ]]; then
+  if [[ -n "$DATA" ]] && [[ -n "$DATA_OLD" ]] && [[ "$DATA_OLD" == "$DATA" ]]; then
     echo "$DATA"
     return 0
   else
     DATA_COUNT=$(echo "$DATA_COUNT + 1" | bc)
     if [[ $DATA_COUNT -gt $MAX_CHECKS ]]; then
-      echo "Data old: $DATA_OLD"
-      echo "Data new: $DATA"
+      printYellow "Data old:"
+      printDebug "$DATA_OLD"
+      printYellow "Data new:"
+      printDebug "$DATA"
       return 1
     fi
     discoverAllZabbix "$DATA" "$DATA_COUNT"
+    STATUS=$?
+    return $STATUS
   fi
 }
 
-testZabbixDiscoverNumberOfStaticPools() {
+checkNumberOfPools() {
+  POOL_TYPE=$1
+  CHECK_COUNT=$2
+
   DATA=$(discoverAllZabbix)
   STATUS=$?
   if [[ $STATUS -ne 0 ]]; then
     echo "$DATA"
+    return 1
   fi
-  assertEquals "Failed to discover all data" "0" "$STATUS"
+  assertEquals "Failed to discover all data when checking pools '$POOL_TYPE'" "0" "$STATUS"
 
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"static' | wc -l)
+  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F "{\"{#POOLNAME}\":\"$POOL_TYPE" | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
-  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  if [[ -n "$CHECK_COUNT" ]] && [[ "$CHECK_COUNT" -ge 0 ]]; then
+    POOLS_BY_DESIGN="$CHECK_COUNT"
+  else
+    POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  fi
+  assertEquals "Number of '$POOL_TYPE' pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  echo "$DATA"
+  return 0
+}
+
+testZabbixDiscoverNumberOfSocketPools() {
+  local DATA
+  DATA=$(checkNumberOfPools "socket")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$DATA"
+  travis_fold_end
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverNumberOfDynamicPools() {
-  DATA=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data" "0" "$STATUS"
-
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"dynamic' | wc -l)
-  PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
-  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  local DATA
+  DATA=$(checkNumberOfPools "dynamic")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$DATA"
+  travis_fold_end
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverNumberOfOndemandPoolsCold() {
-  DATA=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data" "0" "$STATUS"
-
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
+  local DATA
   #If the pools are not started then we have 0 here:
-  assertEquals "Number of pools mismatch" "0" "$NUMBER_OF_POOLS"
+  DATA=$(checkNumberOfPools "ondemand" 0)
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$DATA"
+  travis_fold_end
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverNumberOfOndemandPoolsHot() {
-  PHP_COUNT=$(getNumberOfPHPVersions)
   startOndemandPoolsCache
-
-  DATA=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data" "0" "$STATUS"
-
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
-  PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
-  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  local DATA
+  DATA=$(checkNumberOfPools "ondemand")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$DATA"
+  travis_fold_end
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverNumberOfOndemandPoolsCache() {
-  PHP_COUNT=$(getNumberOfPHPVersions)
   startOndemandPoolsCache
 
-  DATA=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data (initial check)" "0" "$STATUS"
-
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
-  PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
-  assertEquals "Number of pools mismatch (initial check)" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  printAction "Empty cache test..."
+  INITIAL_DATA=$(checkNumberOfPools "ondemand")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$INITIAL_DATA"
+  travis_fold_end
 
   WAIT_TIMEOUT=$(echo "$ONDEMAND_TIMEOUT * 2" | bc)
   sleep "$WAIT_TIMEOUT"
 
-  DATA_CACHE=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data (final check)" "0" "$STATUS"
+  printAction "Full cache test..."
+  CACHED_DATA=$(checkNumberOfPools "ondemand")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$CACHED_DATA"
+  travis_fold_end
 
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
-  PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
-  assertEquals "Number of pools mismatch (final check)" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
-  assertEquals "Data mismatch" "$DATA" "$DATA_CACHE"
+  assertEquals "Data mismatch" "$INITIAL_DATA" "$CACHED_DATA"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverNumberOfIPPools() {
-  DATA=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data" "0" "$STATUS"
-
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"localhost",' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN="$PHP_COUNT"
-  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  local DATA
+  DATA=$(checkNumberOfPools "localhost" "$PHP_COUNT")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$DATA"
+  travis_fold_end
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverNumberOfPortPools() {
-  DATA=$(discoverAllZabbix)
-  STATUS=$?
-  if [[ $STATUS -ne 0 ]]; then
-    echo "$DATA"
-  fi
-  assertEquals "Failed to discover all data" "0" "$STATUS"
-
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"port' | wc -l)
-  PHP_COUNT=$(getNumberOfPHPVersions)
-  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
-  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
+  local DATA
+  DATA=$(checkNumberOfPools "port")
+  travis_fold_start "${FUNCNAME[0]}" "ⓘ Zabbix response"
+  echo "$DATA"
+  travis_fold_end
+  printSuccess "${FUNCNAME[0]}"
 }
 
 #This test should be last in Zabbix tests
@@ -619,26 +842,30 @@ testDiscoverScriptManyPools() {
   setupPools
 
   testDiscoverScriptReturnsData
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverManyPools() {
   testZabbixDiscoverReturnsData
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testDiscoverScriptManyPoolsRunDuration() {
   MAX_RUNS=5
   for ((c = 1; c <= MAX_RUNS; c++)); do
-    echo "Run #$c..."
+    printAction "Run #$c..."
     testDiscoverScriptRunDuration
   done
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testZabbixDiscoverManyPoolsRunDuration() {
   MAX_RUNS=5
   for ((c = 1; c <= MAX_RUNS; c++)); do
-    echo "Run #$c..."
+    printAction "Run #$c..."
     testZabbixDiscoverRunDuration
   done
+  printSuccess "${FUNCNAME[0]}"
 }
 
 # Load shUnit2.

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -27,6 +27,10 @@ copyPool() {
   sudo sed -i "s#listen =.*#listen = $POOL_SOCKET#" "$NEW_POOL_FILE"
   #Pool name
   sudo sed -i "s#\[www\]#[$POOL_NAME]#" "$NEW_POOL_FILE"
+
+  if [[ $POOL_TYPE == "ondemand" ]]; then
+    sudo sed -i 's#;pm.process_idle_timeout.*#pm.process_idle_timeout = 60s#' "$NEW_POOL_FILE"
+  fi
 }
 
 setupPool() {
@@ -126,7 +130,9 @@ oneTimeSetUp() {
 
 tearDown() {
   restoreUserParameters
+  sleep 2
   sudo service zabbix-agent restart
+  sleep 2
 }
 
 testZabbixGetInstalled() {

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -62,7 +62,7 @@ function getRunPHPDirectory() {
   for PHP_TEST_DIR in "${LIST_OF_DIRS[@]}"; do
     RESULT_DIR=$(find "$PHP_TEST_DIR" -name 'php*-fpm.sock' -type s -exec dirname {} \; 2>/dev/null | sort | head -n1)
     if [[ -d "$RESULT_DIR" ]]; then
-      echo "$RESULT_DIR"
+      echo "$RESULT_DIR/"
       return 0
     fi
   done

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -85,14 +85,14 @@ setupPool() {
     copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "ondemand"
   done
 
-  PHP_SERIAL_ID=$(find /etc/php/ -maxdepth 1 -mindepth 1 -type d | sort | grep -n -F "7.3" | cut -d : -f 1)
+  PHP_SERIAL_ID=$(find /etc/php/ -maxdepth 1 -mindepth 1 -type d | sort | grep -n -F "$PHP_VERSION" | cut -d : -f 1)
   #Create TCP port based pools
   #Division on 1 is required to convert from float to integer
   START_PORT=$(echo "($MIN_PORT + $PHP_SERIAL_ID * $MAX_PORTS_COUNT + 1)/1" | bc)
   for ((c = 1; c <= MAX_PORTS; c++)); do
     POOL_NAME="port$c"
     POOL_PORT=$(echo "($START_PORT + $c)/1" | bc)
-    PORT_IS_BUSY=$(sudo lsof -i:$POOL_PORT)
+    PORT_IS_BUSY=$(sudo lsof -i:"$POOL_PORT")
     assertNull "Port $POOL_PORT is busy" "$PORT_IS_BUSY"
     copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_PORT" "static"
   done
@@ -101,7 +101,7 @@ setupPool() {
   POOL_NAME="localhost"
   POOL_PORT=$(echo "($MIN_PORT + $PHP_SERIAL_ID * $MAX_PORTS_COUNT)/1" | bc)
   POOL_SOCKET="127.0.0.1:$POOL_PORT"
-  PORT_IS_BUSY=$(sudo lsof -i:$POOL_PORT)
+  PORT_IS_BUSY=$(sudo lsof -i:"$POOL_PORT")
   assertNull "Port $POOL_PORT is busy" "$PORT_IS_BUSY"
   copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
 

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -224,7 +224,8 @@ function discoverAll() {
   else
     DATA_COUNT=$(echo "$DATA_COUNT + 1" | bc)
     if [[ $DATA_COUNT -gt 10 ]]; then
-      echo "Data old: $DATA_OLD, data new: $DATA"
+      echo "Data old: $DATA_OLD"
+      echo "Data new: $DATA"
       return 1
     fi
     discoverAll "$DATA" "$DATA_COUNT"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -158,7 +158,7 @@ testStatusScriptSocket() {
   PHP_POOL=$(getAnySocket)
 
   #Make the test:
-  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
   echo "Success test of $PHP_POOL"
@@ -169,7 +169,7 @@ testStatusScriptPort() {
   PHP_POOL="127.0.0.1:$PHP_PORT"
 
   #Make the test:
-  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"pool":"')
   assertNotNull "Failed to get status from pool $PHP_POOL: $DATA" "$IS_OK"
   echo "Success test of $PHP_POOL"
@@ -195,13 +195,13 @@ testZabbixStatusPort() {
 }
 
 testDiscoverScriptReturnsData() {
-  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F '{"data":[{"{#POOLNAME}"')
   assertNotNull "Discover script failed: $DATA" "$IS_OK"
 }
 
 testDiscoverScriptDebug() {
-  DATA=$(sudo -u zabbix sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
+  DATA=$(sudo -u zabbix sudo "/etc/zabbix/zabbix_php_fpm_discovery.sh" "debug" "/php-fpm-status")
   ERRORS_LIST=$(echo "$DATA" | grep -F 'Error:')
   assertNull "Discover script errors: $DATA" "$ERRORS_LIST"
 }

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -43,9 +43,21 @@ setupPool() {
 
   #Create new socket pools
   for ((c = 1; c <= MAX_POOLS; c++)); do
-    POOL_NAME="socket$c"
+    POOL_NAME="static$c"
     POOL_SOCKET="/run/php/php${PHP_VERSION}-fpm-${POOL_NAME}.sock"
     copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "static"
+  done
+
+  for ((c = 1; c <= MAX_POOLS; c++)); do
+    POOL_NAME="dynamic$c"
+    POOL_SOCKET="/run/php/php${PHP_VERSION}-fpm-${POOL_NAME}.sock"
+    copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "dynamic"
+  done
+
+  for ((c = 1; c <= MAX_POOLS; c++)); do
+    POOL_NAME="ondemand$c"
+    POOL_SOCKET="/run/php/php${PHP_VERSION}-fpm-${POOL_NAME}.sock"
+    copyPool "$POOL_FILE" "$POOL_NAME" "$POOL_SOCKET" "ondemand"
   done
 
   #Create TCP port based pools
@@ -205,9 +217,23 @@ testZabbixDiscoverReturnsData() {
   assertNotNull "Discover script failed: $DATA" "$IS_OK"
 }
 
-testZabbixDiscoverNumberOfSocketPools() {
+testZabbixDiscoverNumberOfStaticPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"socket1",' | wc -l)
+  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"static' | wc -l)
+  PHP_COUNT=$(getNumberOfPHPVersions)
+  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+}
+
+testZabbixDiscoverNumberOfDynamicPools() {
+  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"dynamic' | wc -l)
+  PHP_COUNT=$(getNumberOfPHPVersions)
+  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+}
+
+testZabbixDiscoverNumberOfOndemandPools() {
+  DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
+  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
   assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
 }

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -465,5 +465,13 @@ testZabbixDiscoverManyPools() {
   testZabbixDiscoverReturnsData
 }
 
+testDiscoverScriptManyPoolsRunDuration() {
+  testDiscoverScriptRunDuration
+}
+
+testZabbixDiscoverManyPoolsRunDuration() {
+  testZabbixDiscoverRunDuration
+}
+
 # Load shUnit2.
 . shunit2

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -8,6 +8,7 @@ MAX_PORTS=3
 MIN_PORT=9000
 TEST_SOCKET=""
 ONDEMAND_TIMEOUT=60
+ZABBIX_TIMEOUT=10
 
 function getUserParameters() {
   sudo find /etc/zabbix/ -name 'userparameter_php_fpm.conf' -type f | head -n1
@@ -171,6 +172,7 @@ oneTimeSetUp() {
 
   #Configure Zabbix:
   echo 'zabbix ALL=NOPASSWD: /etc/zabbix/zabbix_php_fpm_discovery.sh,/etc/zabbix/zabbix_php_fpm_status.sh' | sudo EDITOR='tee -a' visudo
+  sudo sed -i "s#.* Timeout=.*#Timeout = $ZABBIX_TIMEOUT#" "/etc/zabbix/zabbix_agentd.conf"
   sudo service zabbix-agent restart
 
   echo "Setup PHP-FPM..."
@@ -357,7 +359,7 @@ testZabbixDiscoverDoubleRun() {
 function discoverAllZabbix() {
   DATA_OLD=$1
   DATA_COUNT=$2
-  MAX_CHECKS=50
+  MAX_CHECKS=150
 
   if [[ -z $DATA_COUNT ]]; then
     DATA_COUNT=0

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -218,12 +218,13 @@ function discoverAll() {
   fi
 
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
-  if [[ $DATA_OLD == "$DATA" ]]; then
+  if [[ "$DATA_OLD" == "$DATA" ]]; then
     echo "$DATA"
     return 0
   else
     DATA_COUNT=$(echo "$DATA_COUNT + 1" | bc)
     if [[ $DATA_COUNT -gt 10 ]]; then
+      echo "Data old: $DATA_OLD, data new: $DATA"
       return 1
     fi
     discoverAll "$DATA" "$DATA_COUNT"
@@ -233,6 +234,9 @@ function discoverAll() {
 testZabbixDiscoverNumberOfStaticPools() {
   DATA=$(discoverAll)
   STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    echo "$DATA"
+  fi
   assertEquals "Failed to discover all data" "0" "$STATUS"
 
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"static' | wc -l)
@@ -244,6 +248,9 @@ testZabbixDiscoverNumberOfStaticPools() {
 testZabbixDiscoverNumberOfDynamicPools() {
   DATA=$(discoverAll)
   STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    echo "$DATA"
+  fi
   assertEquals "Failed to discover all data" "0" "$STATUS"
 
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"dynamic' | wc -l)
@@ -255,6 +262,9 @@ testZabbixDiscoverNumberOfDynamicPools() {
 testZabbixDiscoverNumberOfOndemandPoolsCold() {
   DATA=$(discoverAll)
   STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    echo "$DATA"
+  fi
   assertEquals "Failed to discover all data" "0" "$STATUS"
 
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
@@ -286,14 +296,12 @@ testZabbixDiscoverNumberOfOndemandPoolsHot() {
     fi
   done <<<"$PHP_LIST"
 
-  OLD_DATA=""
-  DATA="1"
-
-  while
-    [[ $OLD_DATA != "$DATA" ]]
-    OLD_DATA="$DATA"
-    DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
-  do true; done
+  DATA=$(discoverAll)
+  STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    echo "$DATA"
+  fi
+  assertEquals "Failed to discover all data" "0" "$STATUS"
 
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
@@ -304,6 +312,9 @@ testZabbixDiscoverNumberOfOndemandPoolsHot() {
 testZabbixDiscoverNumberOfIPPools() {
   DATA=$(discoverAll)
   STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    echo "$DATA"
+  fi
   assertEquals "Failed to discover all data" "0" "$STATUS"
 
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"localhost",' | wc -l)
@@ -315,6 +326,9 @@ testZabbixDiscoverNumberOfIPPools() {
 testZabbixDiscoverNumberOfPortPools() {
   DATA=$(discoverAll)
   STATUS=$?
+  if [[ $STATUS -ne 0 ]]; then
+    echo "$DATA"
+  fi
   assertEquals "Failed to discover all data" "0" "$STATUS"
 
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"port' | wc -l)

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -9,7 +9,7 @@ MIN_PORT=49001
 MAX_PORTS_COUNT=100
 TEST_SOCKET=""
 ONDEMAND_TIMEOUT=60
-ZABBIX_TIMEOUT=10
+ZABBIX_TIMEOUT=20
 
 function getUserParameters() {
   sudo find /etc/zabbix/ -name 'userparameter_php_fpm.conf' -type f | head -n1

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -234,7 +234,7 @@ testZabbixDiscoverNumberOfOndemandPoolsCold() {
 
 testZabbixDiscoverNumberOfOndemandPoolsHot() {
   # We must start all the pools
-  POOL_URL="/"
+  POOL_URL="/php-fpm-status"
   PHP_COUNT=$(getNumberOfPHPVersions)
 
   PHP_LIST=$(find /etc/php/ -name 'www.conf' -type f)
@@ -251,7 +251,7 @@ testZabbixDiscoverNumberOfOndemandPoolsHot() {
         SCRIPT_FILENAME=$POOL_SOCKET \
         QUERY_STRING=json \
         REQUEST_METHOD=GET \
-        cgi-fcgi -bind -connect "$POOL_URL" 2>/dev/null
+        sudo cgi-fcgi -bind -connect "$POOL_URL" 2>/dev/null
       done
     fi
   done <<<"$PHP_LIST"

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -221,35 +221,40 @@ testZabbixDiscoverNumberOfStaticPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"static' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
 }
 
 testZabbixDiscoverNumberOfDynamicPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"dynamic' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
 }
 
 testZabbixDiscoverNumberOfOndemandPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"ondemand' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
 }
 
 testZabbixDiscoverNumberOfIPPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
   NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"localhost",' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
 }
 
 testZabbixDiscoverNumberOfPortPools() {
   DATA=$(zabbix_get -s 127.0.0.1 -p 10050 -k php-fpm.discover["/php-fpm-status"])
-  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"port1",' | wc -l)
+  NUMBER_OF_POOLS=$(echo "$DATA" | grep -o -F '{"{#POOLNAME}":"port' | wc -l)
   PHP_COUNT=$(getNumberOfPHPVersions)
-  assertEquals "Number of pools mismatch" "$PHP_COUNT" "$NUMBER_OF_POOLS"
+  POOLS_BY_DESIGN=$(echo "$PHP_COUNT * $MAX_POOLS" | bc)
+  assertEquals "Number of pools mismatch" "$POOLS_BY_DESIGN" "$NUMBER_OF_POOLS"
 }
 
 #This test should be last in Zabbix tests

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -267,25 +267,5 @@ testZabbixDiscoverTimeout() {
   testZabbixDiscoverReturnsData
 }
 
-#################################
-#The following tests should be last, no tests of actual data should be done afterwards
-
-testMissingPackagesDiscoveryScript() {
-  sudo apt-get -y purge jq
-
-  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
-  IS_OK=$(echo "$DATA" | grep -F ' not found.')
-  assertNotNull "Discovery script didn't report error on missing utility 'jq'"
-}
-
-testMissingPackagesStatusScript() {
-  sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
-
-  PHP_POOL=$(getAnySocket)
-  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "$PHP_POOL" "/php-fpm-status")
-  IS_OK=$(echo "$DATA" | grep -F ' not found.')
-  assertNotNull "Status script didn't report error on missing utility 'cgi-fcgi'"
-}
-
 # Load shUnit2.
 . shunit2

--- a/tests/missing.sh
+++ b/tests/missing.sh
@@ -3,13 +3,82 @@
 #https://github.com/rvalitov/zabbix-php-fpm
 #This script is used for testing
 
+# Used for section folding in Travis CI
+SECTION_UNIQUE_ID=""
+
+# ----------------------------------
+# Colors
+# ----------------------------------
+NOCOLOR='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+ORANGE='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+LIGHTGRAY='\033[0;37m'
+DARKGRAY='\033[1;30m'
+LIGHTRED='\033[1;31m'
+LIGHTGREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+LIGHTBLUE='\033[1;34m'
+LIGHTPURPLE='\033[1;35m'
+LIGHTCYAN='\033[1;36m'
+WHITE='\033[1;37m'
+
+function printYellow() {
+  local info=$1
+  echo -e "${YELLOW}$info${NOCOLOR}"
+}
+
+function printRed() {
+  local info=$1
+  echo -e "${RED}$info${NOCOLOR}"
+}
+
+function printGreen() {
+  local info=$1
+  echo -e "${LIGHTGREEN}$info${NOCOLOR}"
+}
+
+function printSuccess() {
+  local name=$1
+  printGreen "✓ OK: test '$name' passed"
+}
+
+function printDebug() {
+  local info=$1
+  echo -e "${DARKGRAY}$info${NOCOLOR}"
+}
+
+function printAction() {
+  local info=$1
+  echo -e "${LIGHTBLUE}$info${NOCOLOR}"
+}
+
+function travis_fold_start() {
+  local name=$1
+  local info=$2
+  local CURRENT_TIMING
+  CURRENT_TIMING=$(date +%s%3N)
+  SECTION_UNIQUE_ID="$name.$CURRENT_TIMING"
+  echo -e "travis_fold:start:${SECTION_UNIQUE_ID}\033[33;1m${info}\033[0m"
+}
+
+function travis_fold_end() {
+  echo -e "\ntravis_fold:end:${SECTION_UNIQUE_ID}\r"
+}
+
 oneTimeSetUp() {
-  echo "Started job $TRAVIS_JOB_NAME"
-  echo "Host info:"
+  printAction "Started job $TRAVIS_JOB_NAME"
+
+  travis_fold_start "host_info" "ⓘ Host information"
   nslookup localhost
   sudo ifconfig
   sudo cat /etc/hosts
-  echo "Copying Zabbix files..."
+  travis_fold_end
+
+  printAction "Copying Zabbix files..."
   #Install files:
   sudo cp "$TRAVIS_BUILD_DIR/zabbix/zabbix_php_fpm_discovery.sh" "/etc/zabbix"
   sudo cp "$TRAVIS_BUILD_DIR/zabbix/zabbix_php_fpm_status.sh" "/etc/zabbix"
@@ -17,19 +86,21 @@ oneTimeSetUp() {
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_discovery.sh
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_status.sh
 
-  echo "All done, starting tests..."
+  printAction "All done, starting tests..."
 }
 
 testMissingPackagesDiscoveryScript() {
   DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F ' not found.')
   assertNotNull "Discovery script didn't report error on missing utilities $DATA" "$IS_OK"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 testMissingPackagesStatusScript() {
   DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "localhost:9000" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F ' not found.')
   assertNotNull "Status script didn't report error on missing utilities $DATA" "$IS_OK"
+  printSuccess "${FUNCNAME[0]}"
 }
 
 # Load shUnit2.

--- a/tests/missing.sh
+++ b/tests/missing.sh
@@ -23,13 +23,13 @@ oneTimeSetUp() {
 testMissingPackagesDiscoveryScript() {
   DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F ' not found.')
-  assertNotNull "Discovery script didn't report error on missing utility 'jq'" "$IS_OK"
+  assertNotNull "Discovery script didn't report error on missing utilities $DATA" "$IS_OK"
 }
 
 testMissingPackagesStatusScript() {
   DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "localhost:9000" "/php-fpm-status")
   IS_OK=$(echo "$DATA" | grep -F ' not found.')
-  assertNotNull "Status script didn't report error on missing utility 'cgi-fcgi'" "$IS_OK"
+  assertNotNull "Status script didn't report error on missing utilities $DATA" "$IS_OK"
 }
 
 # Load shUnit2.

--- a/tests/missing.sh
+++ b/tests/missing.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#Ramil Valitov ramilvalitov@gmail.com
+#https://github.com/rvalitov/zabbix-php-fpm
+#This script is used for testing
+
+oneTimeSetUp() {
+  echo "Started job $TRAVIS_JOB_NAME"
+  echo "Host info:"
+  nslookup localhost
+  sudo ifconfig
+  sudo cat /etc/hosts
+  echo "Copying Zabbix files..."
+  #Install files:
+  sudo cp "$TRAVIS_BUILD_DIR/zabbix/zabbix_php_fpm_discovery.sh" "/etc/zabbix"
+  sudo cp "$TRAVIS_BUILD_DIR/zabbix/zabbix_php_fpm_status.sh" "/etc/zabbix"
+  sudo cp "$TRAVIS_BUILD_DIR/zabbix/userparameter_php_fpm.conf" "$(find /etc/zabbix/ -name 'zabbix_agentd*.d' -type d | head -n1)"
+  sudo chmod +x /etc/zabbix/zabbix_php_fpm_discovery.sh
+  sudo chmod +x /etc/zabbix/zabbix_php_fpm_status.sh
+
+  echo "All done, starting tests..."
+}
+
+testMissingPackagesDiscoveryScript() {
+  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_discovery.sh" "/php-fpm-status")
+  IS_OK=$(echo "$DATA" | grep -F ' not found.')
+  assertNotNull "Discovery script didn't report error on missing utility 'jq'" "$IS_OK"
+}
+
+testMissingPackagesStatusScript() {
+  DATA=$(sudo bash "/etc/zabbix/zabbix_php_fpm_status.sh" "localhost:9000" "/php-fpm-status")
+  IS_OK=$(echo "$DATA" | grep -F ' not found.')
+  assertNotNull "Status script didn't report error on missing utility 'cgi-fcgi'" "$IS_OK"
+}
+
+# Load shUnit2.
+. shunit2

--- a/tests/missing.sh
+++ b/tests/missing.sh
@@ -17,6 +17,10 @@ oneTimeSetUp() {
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_discovery.sh
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_status.sh
 
+  sudo apt-get -y purge jq
+  sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
+  sudo apt autoremove
+
   echo "All done, starting tests..."
 }
 

--- a/tests/missing.sh
+++ b/tests/missing.sh
@@ -17,10 +17,6 @@ oneTimeSetUp() {
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_discovery.sh
   sudo chmod +x /etc/zabbix/zabbix_php_fpm_status.sh
 
-  sudo apt-get -y purge jq
-  sudo apt-get -y purge libfcgi-bin libfcgi0ldbl
-  sudo apt autoremove
-
   echo "All done, starting tests..."
 }
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -23,7 +23,7 @@ DEBUG_MODE=""
 USE_SLEEP_TIMEOUT=""
 
 #Sleep timeout in seconds
-SLEEP_TIMEOUT="0.7"
+SLEEP_TIMEOUT="0.5"
 
 #Checking all the required executables
 S_PS=$(type -P ps)
@@ -641,11 +641,11 @@ for POOL_ITEM in "${PENDING_LIST[@]}"; do
   if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]]; then
     ProcessPool "$POOL_NAME" "$POOL_SOCKET"
 
-    #Used for debugging:
-    sleepNow
-
     #Confirm that we run not too much time
     CheckExecutionTime
+
+    #Used for debugging:
+    sleepNow
   fi
 done
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -3,15 +3,15 @@
 #https://github.com/rvalitov/zabbix-php-fpm
 #This script scans local machine for active PHP-FPM pools and returns them as a list in JSON format
 
-#This parameter is used to limit the execution time of this script. Zabbix allows us to run maximum of 3 seconds, so
-#we need to stop and save our state in case we need more time to run. This parameter sets the maximum number of
-#seconds that the script is allowed to run. After this duration is reached, the script will stop running and save its
-#state. So, the actual execution time will be slightly more than this parameter.
-#We put value 2 here, because we can use only integers.
-MAX_EXECUTION_TIME=2
-
-#Reset the seconds variable
-SECONDS=0
+# This parameter is used to limit the execution time of this script.
+# Zabbix allows us to use a script that runs no more than 3 seconds by default. This option can be adjusted in settings:
+# see Timeout option https://www.zabbix.com/forum/zabbix-help/1284-server-agentd-timeout-parameter-in-config
+# So, we need to stop and save our state in case we need more time to run.
+# This parameter sets the maximum number of seconds that the script is allowed to run.
+# After this duration is reached, the script will stop running and save its state.
+# So, the actual execution time will be slightly more than this parameter.
+# We put value equivalent to 2 seconds here.
+MAX_EXECUTION_TIME="2"
 
 #Status path used in calls to PHP-FPM
 STATUS_PATH="/php-fpm-status"
@@ -19,26 +19,11 @@ STATUS_PATH="/php-fpm-status"
 #Debug mode is disabled by default
 DEBUG_MODE=""
 
-#Local directory
-LOCAL_DIR=$(${S_DIRNAME} "$0")
+#Use sleep for testing timeouts, disabled by default. Can be used for testing & debugging
+USE_SLEEP_TIMEOUT=""
 
-#Cache file for ondemand pools
-#File format:
-#<pool name> <socket or TCP>
-ONDEMAND_CACHE_FILE="$LOCAL_DIR/php_fpm_ondemand.cache"
-
-#Cache file for pending pools, used to store execution state
-#File format:
-#<pool name>
-PENDING_FILE="$LOCAL_DIR/php_fpm_pending.cache"
-
-#Cache file with list of active pools, used to store execution state
-#File format:
-#<pool name> <socket or TCP>
-RESULTS_CACHE_FILE="$LOCAL_DIR/php_fpm_results.cache"
-
-#Path to status script, another script of this bundle
-STATUS_SCRIPT="$LOCAL_DIR/zabbix_php_fpm_status.sh"
+#Sleep timeout in seconds
+SLEEP_TIMEOUT="0.7"
 
 #Checking all the required executables
 S_PS=$(type -P ps)
@@ -55,6 +40,9 @@ S_BASH=$(type -P bash)
 S_ECHO=$(type -P echo)
 S_PRINTF=$(type -P printf)
 S_WHOAMI=$(type -P whoami)
+S_DATE=$(type -P date)
+S_BC=$(type -P bc)
+S_SLEEP=$(type -P sleep)
 
 if [[ ! -f $S_PS ]]; then
   ${S_ECHO} "Utility 'ps' not found. Please, install it first."
@@ -108,6 +96,37 @@ if [[ ! -f ${S_WHOAMI} ]]; then
   ${S_ECHO} "Utility 'whoami' not found. Please, install it first."
   exit 1
 fi
+if [[ ! -f ${S_DATE} ]]; then
+  ${S_ECHO} "Utility 'date' not found. Please, install it first."
+  exit 1
+fi
+if [[ ! -f $S_BC ]]; then
+  $S_ECHO "Utility 'bc' not found. Please, install it first."
+  exit 1
+fi
+if [[ ! -f $S_SLEEP ]]; then
+  $S_ECHO "Utility 'sleep' not found. Please, install it first."
+  exit 1
+fi
+
+#Local directory
+LOCAL_DIR=$(${S_DIRNAME} "$0")
+
+#Cache file for pending pools, used to store execution state
+#File format:
+#<pool name> <socket or TCP>
+PENDING_FILE="$LOCAL_DIR/php_fpm_pending.cache"
+
+#Cache file with list of active pools, used to store execution state
+#File format:
+#<pool name> <socket or TCP> <pool manager type>
+RESULTS_CACHE_FILE="$LOCAL_DIR/php_fpm_results.cache"
+
+#Path to status script, another script of this bundle
+STATUS_SCRIPT="$LOCAL_DIR/zabbix_php_fpm_status.sh"
+
+#Start time of the script
+START_TIME=$($S_DATE +%s)
 
 ACTIVE_USER=$(${S_WHOAMI})
 
@@ -140,57 +159,201 @@ function EncodeToJson() {
   return 1
 }
 
-# Checks if selected pool is in cache.
+# Updates information about the pool in cache.
 # Input arguments:
 # - pool name
 # - pool socket
-# Function returns 1 if the pool is in cache, and 0 otherwise.
-function IsInCache() {
-  SEARCH_NAME=$1
-  SEARCH_SOCKET=$2
-  if [[ -z ${SEARCH_NAME} ]] || [[ -z ${SEARCH_SOCKET} ]]; then
+# - pool type
+function UpdatePoolInCache() {
+  POOL_NAME=$1
+  POOL_SOCKET=$2
+  POOL_TYPE=$3
+
+  if [[ -z $POOL_NAME ]] || [[ -z $POOL_SOCKET ]] || [[ -z $POOL_TYPE ]]; then
+    PrintDebug "Error: Invalid arguments for UpdatePoolInCache"
     return 0
   fi
-  for CACHE_ITEM in "${NEW_CACHE[@]}"; do
+
+  for ITEM_INDEX in "${!CACHE[@]}"; do
+    CACHE_ITEM="${CACHE[$ITEM_INDEX]}"
     # shellcheck disable=SC2016
     ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
     # shellcheck disable=SC2016
     ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
-    if [[ ${ITEM_NAME} == "${SEARCH_NAME}" ]] && [[ ${ITEM_SOCKET} == "${SEARCH_SOCKET}" ]]; then
+    # shellcheck disable=SC2016
+    ITEM_POOL_TYPE=$($S_ECHO "$CACHE_ITEM" | ${S_AWK} '{print $3}')
+    if [[ $ITEM_NAME == "$POOL_NAME" && $ITEM_SOCKET == "$POOL_SOCKET" ]] || [[ -z $ITEM_POOL_TYPE ]]; then
+      PrintDebug "Pool $POOL_NAME $POOL_SOCKET is in cache, deleting..."
+      #Deleting the pool first
+      mapfile -d $'\0' -t CACHE < <($S_PRINTF '%s\0' "${CACHE[@]}" | $S_GREP -Fwzv "$ITEM_NAME $ITEM_SOCKET")
+    fi
+  done
+
+  CACHE+=("$POOL_NAME $POOL_SOCKET $POOL_TYPE")
+  PrintDebug "Added pool $POOL_NAME $POOL_SOCKET to cache list"
+  return 0
+}
+
+# Removes pools from cache that are currently inactive and are missing in pending list
+function UpdateCacheList() {
+  for ITEM_INDEX in "${!CACHE[@]}"; do
+    CACHE_ITEM="${CACHE[$ITEM_INDEX]}"
+    # shellcheck disable=SC2016
+    ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
+    # shellcheck disable=SC2016
+    ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
+    # shellcheck disable=SC2016
+    ITEM_POOL_TYPE=$($S_ECHO "$CACHE_ITEM" | ${S_AWK} '{print $3}')
+
+    if [[ $ITEM_NAME == "$POOL_NAME" && $ITEM_SOCKET == "$POOL_SOCKET" ]] || [[ -z $ITEM_POOL_TYPE ]]; then
+      PrintDebug "Pool $POOL_NAME $POOL_SOCKET is in cache, deleting..."
+      #Deleting the pool first
+      mapfile -d $'\0' -t CACHE < <($S_PRINTF '%s\0' "${CACHE[@]}" | $S_GREP -Fwzv "ITEM_NAME $ITEM_SOCKET")
+    fi
+  done
+}
+
+# Checks if selected pool is in pending list
+# Function returns 1 if pool is in list, and 0 otherwise
+function IsInPendingList() {
+  POOL_NAME=$1
+  POOL_SOCKET=$2
+
+  if [[ -z $POOL_NAME ]] || [[ -z $POOL_SOCKET ]]; then
+    PrintDebug "Error: Invalid arguments for IsInPendingList"
+    return 0
+  fi
+
+  for ITEM in "${PENDING_LIST[@]}"; do
+    if [[ "$ITEM" == "$POOL_NAME $POOL_SOCKET" ]]; then
       return 1
     fi
   done
   return 0
 }
 
+# Adds a pool to the pending list
+# The pool is added only if it's not already in the list.
+# A new pool is added to the end of the list.
+# Function returns 1, if a pool was added, and 0 otherwise.
+function AddPoolToPendingList() {
+  POOL_NAME=$1
+  POOL_SOCKET=$2
+
+  if [[ -z $POOL_NAME ]] || [[ -z $POOL_SOCKET ]]; then
+    PrintDebug "Error: Invalid arguments for AddPoolToPendingList"
+    return 0
+  fi
+
+  IsInPendingList "$POOL_NAME" "$POOL_SOCKET"
+  FOUND=$?
+
+  if [[ ${FOUND} == 1 ]]; then
+    #Already in list, quit
+    PrintDebug "Pool $POOL_NAME $POOL_SOCKET is already in pending list"
+    return 0
+  fi
+
+  #Otherwise add this pool to the end of the list
+  PENDING_LIST+=("$POOL_NAME $POOL_SOCKET")
+  PrintDebug "Added pool $POOL_NAME $POOL_SOCKET to pending list"
+  return 1
+}
+
+# Removes a pool from pending list
+# Returns 1 if success, 0 otherwise
+function DeletePoolFromPendingList() {
+  POOL_NAME=$1
+  POOL_SOCKET=$2
+
+  if [[ -z $POOL_NAME ]] || [[ -z $POOL_SOCKET ]]; then
+    PrintDebug "Error: Invalid arguments for DeletePoolFromPendingList"
+    return 0
+  fi
+
+  IsInPendingList "$POOL_NAME" "$POOL_SOCKET"
+  FOUND=$?
+
+  if [[ ${FOUND} == 0 ]]; then
+    #Not in list, quit
+    PrintDebug "Error: Pool $POOL_NAME $POOL_SOCKET is already missing in pending list"
+    return 0
+  fi
+
+  #Otherwise we remove this pool from the list
+  mapfile -d $'\0' -t PENDING_LIST < <($S_PRINTF '%s\0' "${PENDING_LIST[@]}" | $S_GREP -Fxzv "$POOL_NAME $POOL_SOCKET")
+  PrintDebug "Removed pool $POOL_NAME $POOL_SOCKET from pending list"
+  return 1
+}
+
+function SavePrintResults() {
+  #Saving pending list:
+  if [[ -f $PENDING_FILE ]] && [[ ! -w $PENDING_FILE ]]; then
+    ${S_ECHO} "Error: write permission is not granted to user $ACTIVE_USER for cache file $PENDING_FILE"
+    exit 1
+  fi
+
+  PrintDebug "Saving pending pools list to file $PENDING_FILE..."
+  ${S_PRINTF} "%s\n" "${PENDING_LIST[@]}" >"$PENDING_FILE"
+
+  if [[ -n $DEBUG_MODE ]]; then
+    PrintDebug "List of pools to be saved to cache pools file:"
+    PrintCacheList
+  fi
+
+  if [[ -f $RESULTS_CACHE_FILE ]] && [[ ! -w $RESULTS_CACHE_FILE ]]; then
+    ${S_ECHO} "Error: write permission is not granted to user $ACTIVE_USER for cache file $RESULTS_CACHE_FILE"
+    exit 1
+  fi
+
+  PrintDebug "Saving cache file to file $RESULTS_CACHE_FILE..."
+  ${S_PRINTF} "%s\n" "${CACHE[@]}" >"$RESULTS_CACHE_FILE"
+
+  POOL_FIRST=0
+  #We store the resulting JSON data for Zabbix in the following var:
+  RESULT_DATA="{\"data\":["
+
+  for CACHE_ITEM in "${CACHE[@]}"; do
+    # shellcheck disable=SC2016
+    ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
+    # shellcheck disable=SC2016
+    ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
+    EncodeToJson "${ITEM_NAME}" "${ITEM_SOCKET}"
+  done
+
+  RESULT_DATA="$RESULT_DATA]}"
+  PrintDebug "Resulting JSON data for Zabbix:"
+  ${S_ECHO} -n "$RESULT_DATA"
+}
+
 function CheckExecutionTime() {
-  if [[ $SECONDS -lt $MAX_EXECUTION_TIME ]]; then
+  CURRENT_TIME=$($S_DATE +%s)
+  ELAPSED_TIME=$($S_ECHO "$CURRENT_TIME - $START_TIME" | $S_BC)
+  if [[ $ELAPSED_TIME -lt $MAX_EXECUTION_TIME ]]; then
     #All good, we can continue
-    return 1;
+    PrintDebug "Check execution time OK"
+    return 1
   fi
 
   #We need to save our state and exit
+  PrintDebug "Check execution time: stop required"
+
+  SavePrintResults
+
+  exit 0
 }
 
 # Validates the specified pool by getting its status and working with cache.
 # Pass two arguments: pool name and pool socket
 # Function returns:
 # 0 if the pool is invalid
-# 1 if the pool is OK and is ondemand and is not in cache
-# 2 if the pool is OK and is ondemand and is in cache
-# 3 if the pool is OK and is not ondemand and is not in cache
-function ProcessPool() {
+# 1 if the pool is OK
+function CheckPool() {
   POOL_NAME=$1
   POOL_SOCKET=$2
   if [[ -z ${POOL_NAME} ]] || [[ -z ${POOL_SOCKET} ]]; then
-    PrintDebug "Invalid arguments for ProcessPool"
+    PrintDebug "Error: Invalid arguments for CheckPool"
     return 0
-  fi
-
-  IsInCache "${POOL_NAME}" "${POOL_SOCKET}"
-  FOUND=$?
-  if [[ ${FOUND} == 1 ]]; then
-    return 2
   fi
 
   STATUS_JSON=$(${S_BASH} "${STATUS_SCRIPT}" "${POOL_SOCKET}" ${STATUS_PATH})
@@ -202,14 +365,15 @@ function ProcessPool() {
     # We use basic regular expression here, i.e. we need to use \+ and not escape { and }
     if [[ -n $(${S_ECHO} "${STATUS_JSON}" | ${S_GREP} -G '^{.*\"pool\":\".\+\".*,\"process manager\":\".\+\".*}$') ]]; then
       PrintDebug "Status data for pool $POOL_NAME, socket $POOL_SOCKET, status path $STATUS_PATH is valid"
-      # Checking if we have ondemand pool
-      if [[ -n $(${S_ECHO} "${STATUS_JSON}" | ${S_GREP} -F '"process manager":"ondemand"') ]]; then
-        PrintDebug "Detected pool's process manager is ondemand, it needs to be cached"
-        NEW_CACHE+=("$POOL_NAME $POOL_SOCKET")
+
+      PROCESS_MANAGER=$($S_ECHO "$STATUS_JSON" | $S_GREP -oP '"process manager":"\K([a-z]+)')
+      if [[ -n $PROCESS_MANAGER ]]; then
+        PrintDebug "Detected pool's process manager is $PROCESS_MANAGER"
+        UpdatePoolInCache "$POOL_NAME" "$POOL_SOCKET" "$PROCESS_MANAGER"
         return 1
+      else
+        PrintDebug "Error: Failed to detect process manager of the pool"
       fi
-      PrintDebug "Detected pool's process manager is NOT ondemand, it will not be cached"
-      return 3
     fi
 
     PrintDebug "Failed to validate status data for pool $POOL_NAME, socket $POOL_SOCKET, status path $STATUS_PATH"
@@ -225,10 +389,174 @@ function ProcessPool() {
   return 0
 }
 
+#Sleeps for a specified predefined amount of time. Works only if "sleep mode" is enabled.
+function sleepNow() {
+  if [[ -n $USE_SLEEP_TIMEOUT ]]; then
+    PrintDebug "Debug: Sleep for $SLEEP_TIMEOUT sec"
+    $S_SLEEP "$SLEEP_TIMEOUT"
+  fi
+}
+
+# Analysis of pool by name, scans the processes, and adds them to pending list for further checks
+function AnalyzePool() {
+  POOL_NAME=$1
+  if [[ -z ${POOL_NAME} ]]; then
+    PrintDebug "Invalid arguments for AnalyzePool"
+    return 0
+  fi
+
+  # shellcheck disable=SC2016
+  POOL_PID_LIST=$(${S_PRINTF} '%s\n' "${PS_LIST[@]}" | $S_GREP -F -w "php-fpm: pool $POOL_NAME" | $S_AWK '{print $1}')
+  POOL_PID_ARGS=""
+  while IFS= read -r POOL_PID; do
+    if [[ -n $POOL_PID ]]; then
+      POOL_PID_ARGS="$POOL_PID_ARGS -p $POOL_PID"
+    fi
+  done <<<"$POOL_PID_LIST"
+
+  if [[ -n $POOL_PID_ARGS ]]; then
+    #We search for socket or IP address and port
+    #Socket example:
+    #php-fpm7. 25897 root 9u unix 0x000000006509e31f 0t0 58381847 /run/php/php7.3-fpm.sock type=STREAM
+    #IP example:
+    #php-fpm7. 1110 default 0u IPv4 15760 0t0 TCP localhost:8002 (LISTEN)
+
+    #Check all matching processes, because we may face a redirect (or a symlink?), examples:
+    #php-fpm7. 1203 www-data 5u unix 0x000000006509e31f 0t0 15068771 type=STREAM
+    #php-fpm7. 6086 www-data 11u IPv6 21771 0t0 TCP *:9000 (LISTEN)
+    #php-fpm7. 1203 www-data 8u IPv4 15070917 0t0 TCP localhost.localdomain:23054->localhost.localdomain:postgresql (ESTABLISHED)
+    #More info at https://github.com/rvalitov/zabbix-php-fpm/issues/12
+
+    PrintDebug "Started analysis of pool $POOL_NAME, PID(s): $POOL_PID_ARGS"
+    #Extract only important information:
+    #Use -P to show port number instead of port name, see https://github.com/rvalitov/zabbix-php-fpm/issues/24
+    #Use -n flag to show IP address and not convert it to domain name (like localhost)
+    #Sometimes different PHP-FPM versions may have the same names of pools, so we need to consider that.
+    # It's considered that a pair of pool name and socket must be unique.
+    #Sorting is required, because uniq needs it
+    # shellcheck disable=SC2086
+    POOL_PARAMS_LIST=$($S_LSOF -n -P $POOL_PID_ARGS 2>/dev/null | $S_GREP -w -e "unix" -e "TCP" | $S_SORT -u | $S_UNIQ -f8)
+    FOUND_POOL=""
+    while IFS= read -r pool; do
+      if [[ -n $pool ]]; then
+        PrintDebug "Checking process: $pool"
+        # shellcheck disable=SC2016
+        POOL_TYPE=$(${S_ECHO} "${pool}" | $S_AWK '{print $5}')
+        # shellcheck disable=SC2016
+        POOL_SOCKET=$(${S_ECHO} "${pool}" | $S_AWK '{print $9}')
+        if [[ -n $POOL_TYPE ]] && [[ -n $POOL_SOCKET ]]; then
+          if [[ $POOL_TYPE == "unix" ]]; then
+            #We have a socket here, test if it's actually a socket:
+            if [[ -S $POOL_SOCKET ]]; then
+              FOUND_POOL="1"
+              PrintDebug "Found socket $POOL_SOCKET"
+              AddPoolToPendingList "$POOL_NAME" "$POOL_SOCKET"
+            else
+              PrintDebug "Error: specified socket $POOL_SOCKET is not valid"
+            fi
+          elif [[ $POOL_TYPE == "IPv4" ]] || [[ $POOL_TYPE == "IPv6" ]]; then
+            #We have a TCP connection here, check it:
+            # shellcheck disable=SC2016
+            CONNECTION_TYPE=$(${S_ECHO} "${pool}" | $S_AWK '{print $8}')
+            if [[ $CONNECTION_TYPE == "TCP" ]]; then
+              #The connection must have state LISTEN:
+              LISTEN=$(${S_ECHO} "${pool}" | $S_GREP -F -w "(LISTEN)")
+              if [[ -n $LISTEN ]]; then
+                #Check and replace * to localhost if it's found. Asterisk means that the PHP listens on
+                #all interfaces.
+                FOUND_POOL="1"
+                PrintDebug "Found TCP connection $POOL_SOCKET"
+                POOL_SOCKET=${POOL_SOCKET/\*:/localhost:}
+                AddPoolToPendingList "$POOL_NAME" "$POOL_SOCKET"
+              else
+                PrintDebug "Warning: expected connection state must be LISTEN, but it was not detected"
+              fi
+            else
+              PrintDebug "Warning: expected connection type is TCP, but found $CONNECTION_TYPE"
+            fi
+          else
+            PrintDebug "Unsupported type $POOL_TYPE, skipping"
+          fi
+        else
+          PrintDebug "Warning: pool type or socket is empty"
+        fi
+      else
+        PrintDebug "Error: failed to get process information. Probably insufficient privileges. Use sudo or run this script under root."
+      fi
+    done <<<"$POOL_PARAMS_LIST"
+
+    if [[ -z ${FOUND_POOL} ]]; then
+      PrintDebug "Error: failed to discover information for pool $POOL_NAME"
+    fi
+  else
+    PrintDebug "Error: failed to find PID for pool $POOL_NAME"
+  fi
+
+  return 1
+}
+
+# Prints list of pools in pending list
+function PrintPendingList() {
+  COUNTER=1
+  for POOL_ITEM in "${PENDING_LIST[@]}"; do
+    # shellcheck disable=SC2016
+    POOL_NAME=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $1}')
+    # shellcheck disable=SC2016
+    POOL_SOCKET=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $2}')
+    if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]]; then
+      PrintDebug "#$COUNTER $POOL_NAME $POOL_SOCKET"
+      COUNTER=$($S_ECHO "$COUNTER + 1" | $S_BC)
+    fi
+  done
+}
+
+# Prints list of pools in cache
+function PrintCacheList() {
+  COUNTER=1
+  for POOL_ITEM in "${CACHE[@]}"; do
+    # shellcheck disable=SC2016
+    POOL_NAME=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $1}')
+    # shellcheck disable=SC2016
+    POOL_SOCKET=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $2}')
+    # shellcheck disable=SC2016
+    PROCESS_MANAGER=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $3}')
+    if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]] && [[ -n "$PROCESS_MANAGER" ]]; then
+      PrintDebug "#$COUNTER $POOL_NAME $POOL_SOCKET $PROCESS_MANAGER"
+      COUNTER=$($S_ECHO "$COUNTER + 1" | $S_BC)
+    fi
+  done
+}
+
+# Functions processes a pool by name: makes all required checks and adds it to cache, etc.
+function ProcessPool() {
+  POOL_NAME=$1
+  POOL_SOCKET=$2
+  if [[ -z $POOL_NAME ]] || [[ -z $POOL_SOCKET ]]; then
+    PrintDebug "Invalid arguments for ProcessPool"
+    return 0
+  fi
+
+  PrintDebug "Processing pool $POOL_NAME $POOL_SOCKET"
+  CheckPool "$POOL_NAME" "${POOL_SOCKET}"
+  POOL_STATUS=$?
+  if [[ ${POOL_STATUS} -gt 0 ]]; then
+    FOUND_POOL="1"
+    PrintDebug "Success: socket $POOL_SOCKET returned valid status data"
+  else
+    PrintDebug "Error: socket $POOL_SOCKET didn't return valid data"
+  fi
+
+  DeletePoolFromPendingList "$POOL_NAME" "$POOL_SOCKET"
+  return 1
+}
+
 for ARG in "$@"; do
   if [[ ${ARG} == "debug" ]]; then
     DEBUG_MODE="1"
     ${S_ECHO} "Debug mode enabled"
+  elif [[ ${ARG} == "sleep" ]]; then
+    USE_SLEEP_TIMEOUT="1"
+    ${S_ECHO} "Debug: Sleep timeout enabled"
   elif [[ ${ARG} == /* ]]; then
     STATUS_PATH=${ARG}
     PrintDebug "Argument $ARG is interpreted as status path"
@@ -250,157 +578,65 @@ if [[ ! -r ${STATUS_SCRIPT} ]]; then
 fi
 PrintDebug "Helper script $STATUS_SCRIPT is reachable"
 
-# Loading cached data for ondemand pools.
-# The cache file consists of lines, each line contains pool name, then space, then socket (or TCP info)
+# Loading cached data for pools.
 CACHE=()
-NEW_CACHE=()
-if [[ -r ${ONDEMAND_CACHE_FILE} ]]; then
-  PrintDebug "Reading cache file of ondemand pools $ONDEMAND_CACHE_FILE..."
-  mapfile -t CACHE < <(${S_CAT} "${ONDEMAND_CACHE_FILE}")
+if [[ -r $RESULTS_CACHE_FILE ]]; then
+  PrintDebug "Reading cache file of pools $RESULTS_CACHE_FILE..."
+  mapfile -t CACHE < <(${S_CAT} "$RESULTS_CACHE_FILE")
 else
-  PrintDebug "Cache file of ondemand pools $ONDEMAND_CACHE_FILE not found, skipping..."
+  PrintDebug "Cache file of pools $RESULTS_CACHE_FILE not found, skipping..."
+fi
+
+if [[ -n $DEBUG_MODE ]]; then
+  PrintDebug "List of pools loaded from cache pools file:"
+  PrintCacheList
 fi
 
 #Loading pending tasks
 PENDING_LIST=()
 if [[ -r $PENDING_FILE ]]; then
-  PrintDebug "Reading file of pending pools ${PENDING_FILE}..."
-  mapfile -t PENDING_LIST < <(${S_CAT} "${PENDING_FILE}")
+  PrintDebug "Reading file of pending pools $PENDING_FILE..."
+  mapfile -t PENDING_LIST < <($S_CAT "$PENDING_FILE")
 else
-  PrintDebug "List of pending pools ${PENDING_FILE} not found, skipping..."
+  PrintDebug "List of pending pools $PENDING_FILE not found, skipping..."
+fi
+
+if [[ -n $DEBUG_MODE ]]; then
+  PrintDebug "List of pools loaded from pending pools file:"
+  PrintPendingList
 fi
 
 mapfile -t PS_LIST < <($S_PS ax | $S_GREP -F "php-fpm: pool " | $S_GREP -F -v "grep")
 # shellcheck disable=SC2016
 POOL_NAMES_LIST=$(${S_PRINTF} '%s\n' "${PS_LIST[@]}" | $S_AWK '{print $NF}' | $S_SORT -u)
-POOL_FIRST=0
-#We store the resulting JSON data for Zabbix in the following var:
-RESULT_DATA="{\"data\":["
-while IFS= read -r line; do
-  # shellcheck disable=SC2016
-  POOL_PID_LIST=$(${S_PRINTF} '%s\n' "${PS_LIST[@]}" | $S_GREP -F -w "php-fpm: pool $line" | $S_AWK '{print $1}')
-  POOL_PID_ARGS=""
-  while IFS= read -r POOL_PID; do
-    if [[ -n $POOL_PID ]]; then
-      POOL_PID_ARGS="$POOL_PID_ARGS -p $POOL_PID"
-    fi
-  done <<<"$POOL_PID_LIST"
 
-  if [[ -n $POOL_PID_ARGS ]]; then
-    #We search for socket or IP address and port
-    #Socket example:
-    #php-fpm7. 25897 root 9u unix 0x000000006509e31f 0t0 58381847 /run/php/php7.3-fpm.sock type=STREAM
-    #IP example:
-    #php-fpm7. 1110 default 0u IPv4 15760 0t0 TCP localhost:8002 (LISTEN)
-
-    #Check all matching processes, because we may face a redirect (or a symlink?), examples:
-    #php-fpm7. 1203 www-data 5u unix 0x000000006509e31f 0t0 15068771 type=STREAM
-    #php-fpm7. 6086 www-data 11u IPv6 21771 0t0 TCP *:9000 (LISTEN)
-    #php-fpm7. 1203 www-data 8u IPv4 15070917 0t0 TCP localhost.localdomain:23054->localhost.localdomain:postgresql (ESTABLISHED)
-    #More info at https://github.com/rvalitov/zabbix-php-fpm/issues/12
-
-    PrintDebug "Started analysis of pool $line, PID(s): $POOL_PID_ARGS"
-    #Extract only important information:
-    #Use -P to show port number instead of port name, see https://github.com/rvalitov/zabbix-php-fpm/issues/24
-    #Use -n flag to show IP address and not convert it to domain name (like localhost)
-    #Sometimes different PHP-FPM versions may have the same names of pools, so we need to consider that.
-    # It's considered that a pair of pool name and socket must be unique.
-    #Sorting is required, because uniq needs it
-    POOL_PARAMS_LIST=$($S_LSOF -n -P $POOL_PID_ARGS 2>/dev/null | $S_GREP -w -e "unix" -e "TCP" | $S_SORT -u | $S_UNIQ -f8)
-    FOUND_POOL=""
-    while IFS= read -r pool; do
-      if [[ -n $pool ]]; then
-        PrintDebug "Checking process: $pool"
-        # shellcheck disable=SC2016
-        POOL_TYPE=$(${S_ECHO} "${pool}" | $S_AWK '{print $5}')
-        # shellcheck disable=SC2016
-        POOL_SOCKET=$(${S_ECHO} "${pool}" | $S_AWK '{print $9}')
-        if [[ -n $POOL_TYPE ]] && [[ -n $POOL_SOCKET ]]; then
-          if [[ $POOL_TYPE == "unix" ]]; then
-            #We have a socket here, test if it's actually a socket:
-            if [[ -S $POOL_SOCKET ]]; then
-              PrintDebug "Found socket $POOL_SOCKET"
-              ProcessPool "${line}" "${POOL_SOCKET}"
-              POOL_STATUS=$?
-              if [[ ${POOL_STATUS} -gt 0 ]]; then
-                FOUND_POOL="1"
-                PrintDebug "Success: socket $POOL_SOCKET returned valid status data"
-                EncodeToJson "${line}" "${POOL_SOCKET}"
-              else
-                PrintDebug "Error: socket $POOL_SOCKET didn't return valid data"
-              fi
-            else
-              PrintDebug "Error: specified socket $POOL_SOCKET is not valid"
-            fi
-          elif [[ $POOL_TYPE == "IPv4" ]] || [[ $POOL_TYPE == "IPv6" ]]; then
-            #We have a TCP connection here, check it:
-            # shellcheck disable=SC2016
-            CONNECTION_TYPE=$(${S_ECHO} "${pool}" | $S_AWK '{print $8}')
-            if [[ $CONNECTION_TYPE == "TCP" ]]; then
-              #The connection must have state LISTEN:
-              LISTEN=$(${S_ECHO} "${pool}" | $S_GREP -F -w "(LISTEN)")
-              if [[ -n $LISTEN ]]; then
-                #Check and replace * to localhost if it's found. Asterisk means that the PHP listens on
-                #all interfaces.
-                PrintDebug "Found TCP connection $POOL_SOCKET"
-                POOL_SOCKET=${POOL_SOCKET/\*:/localhost:}
-                PrintDebug "Processed TCP connection $POOL_SOCKET"
-                ProcessPool "${line}" "${POOL_SOCKET}"
-                POOL_STATUS=$?
-                if [[ ${POOL_STATUS} -gt 0 ]]; then
-                  FOUND_POOL="1"
-                  PrintDebug "Success: TCP connection $POOL_SOCKET returned valid status data"
-                  EncodeToJson "${line}" "${POOL_SOCKET}"
-                else
-                  PrintDebug "Error: TCP connection $POOL_SOCKET didn't return valid data"
-                fi
-              else
-                PrintDebug "Warning: expected connection state must be LISTEN, but it was not detected"
-              fi
-            else
-              PrintDebug "Warning: expected connection type is TCP, but found $CONNECTION_TYPE"
-            fi
-          else
-            PrintDebug "Unsupported type $POOL_TYPE, skipping"
-          fi
-        else
-          PrintDebug "Warning: pool type or socket is empty"
-        fi
-      else
-        PrintDebug "Error: failed to get process information. Probably insufficient privileges. Use sudo or run this script under root."
-      fi
-    done <<<"$POOL_PARAMS_LIST"
-
-    if [[ -z ${FOUND_POOL} ]]; then
-      PrintDebug "Error: failed to discover information for pool $line"
-    fi
-  else
-    PrintDebug "Error: failed to find PID for pool $line"
-  fi
+#Update pending list with pools that are active and running
+while IFS= read -r POOL_NAME; do
+  AnalyzePool "$POOL_NAME"
 done <<<"$POOL_NAMES_LIST"
 
-PrintDebug "Processing pools from old cache..."
-for CACHE_ITEM in "${CACHE[@]}"; do
+if [[ -n $DEBUG_MODE ]]; then
+  PrintDebug "Pending list generated:"
+  PrintPendingList
+fi
+
+#Process pending list
+PrintDebug "Processing pools"
+
+for POOL_ITEM in "${PENDING_LIST[@]}"; do
   # shellcheck disable=SC2016
-  ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
+  POOL_NAME=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $1}')
   # shellcheck disable=SC2016
-  ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
-  ProcessPool "${ITEM_NAME}" "${ITEM_SOCKET}"
-  POOL_STATUS=$?
-  if [[ ${POOL_STATUS} == "1" ]]; then
-    # This is a new pool and we must add it
-    EncodeToJson "${ITEM_NAME}" "${ITEM_SOCKET}"
+  POOL_SOCKET=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $2}')
+  if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]]; then
+    ProcessPool "$POOL_NAME" "$POOL_SOCKET"
+
+    #Used for debugging:
+    sleepNow
+
+    #Confirm that we run not too much time
+    CheckExecutionTime
   fi
 done
 
-if [[ -f ${ONDEMAND_CACHE_FILE} ]] && [[ ! -w ${ONDEMAND_CACHE_FILE} ]]; then
-  ${S_ECHO} "Error: write permission is not granted to user $ACTIVE_USER for cache file $ONDEMAND_CACHE_FILE"
-  exit 1
-fi
-
-PrintDebug "Saving new cache file $ONDEMAND_CACHE_FILE..."
-${S_PRINTF} "%s\n" "${NEW_CACHE[@]}" >"${ONDEMAND_CACHE_FILE}"
-
-RESULT_DATA="$RESULT_DATA]}"
-PrintDebug "Resulting JSON data for Zabbix:"
-${S_ECHO} -n "$RESULT_DATA"
+SavePrintResults

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -338,12 +338,12 @@ function CheckExecutionTime() {
   ELAPSED_TIME=$(echo "$CURRENT_TIME - $START_TIME" | $S_BC)
   if [[ $ELAPSED_TIME -lt $MAX_EXECUTION_TIME ]]; then
     #All good, we can continue
-    PrintDebug "Check execution time OK"
+    PrintDebug "Check execution time OK, elapsed $ELAPSED_TIME"
     return 1
   fi
 
   #We need to save our state and exit
-  PrintDebug "Check execution time: stop required"
+  PrintDebug "Check execution time: stop required, elapsed $ELAPSED_TIME"
 
   SavePrintResults
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -561,6 +561,9 @@ for ARG in "$@"; do
   elif [[ ${ARG} == "sleep" ]]; then
     USE_SLEEP_TIMEOUT="1"
     echo "Debug: Sleep timeout enabled"
+  elif [[ ${ARG} == "nosleep" ]]; then
+    MAX_EXECUTION_TIME="10000000"
+    echo "Debug: Timeout checks disabled"
   elif [[ ${ARG} == /* ]]; then
     STATUS_PATH=${ARG}
     PrintDebug "Argument $ARG is interpreted as status path"

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -42,6 +42,7 @@ S_WHOAMI=$(type -P whoami)
 S_DATE=$(type -P date)
 S_BC=$(type -P bc)
 S_SLEEP=$(type -P sleep)
+S_FCGI=$(type -P cgi-fcgi)
 
 if [[ ! -x $S_PS ]]; then
   echo "Utility 'ps' not found. Please, install it first."
@@ -105,6 +106,10 @@ if [[ ! -x $S_BC ]]; then
 fi
 if [[ ! -x $S_SLEEP ]]; then
   echo "Utility 'sleep' not found. Please, install it first."
+  exit 1
+fi
+if [[ ! -x $S_FCGI ]]; then
+  echo "Utility 'cgi-fcgi' not found. Please, install it first."
   exit 1
 fi
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -301,7 +301,7 @@ function SavePrintResults() {
   ${S_PRINTF} "%s\n" "${PENDING_LIST[@]}" >"$PENDING_FILE"
 
   #We must sort the cache list
-  readarray -t CACHE < <(for a in "${CACHE[@]}"; do echo "$a"; done | sort)
+  readarray -t CACHE < <(for a in "${CACHE[@]}"; do echo "$a"; done | $S_SORT)
 
   if [[ -n $DEBUG_MODE ]]; then
     PrintDebug "List of pools to be saved to cache pools file:"

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -237,7 +237,8 @@ while IFS= read -r line; do
 
     PrintDebug "Started analysis of pool $line, PID $POOL_PID"
     #Extract only important information:
-    POOL_PARAMS_LIST=$($S_LSOF -p "$POOL_PID" 2>/dev/null | $S_GREP -w -e "unix" -e "TCP")
+    #Use -P to show port number instead of port name, see https://github.com/rvalitov/zabbix-php-fpm/issues/24
+    POOL_PARAMS_LIST=$($S_LSOF -P -p "$POOL_PID" 2>/dev/null | $S_GREP -w -e "unix" -e "TCP")
     FOUND_POOL=""
     while IFS= read -r pool; do
       if [[ -n $pool ]]; then

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -37,7 +37,6 @@ S_JQ=$(type -P jq)
 S_DIRNAME=$(type -P dirname)
 S_CAT=$(type -P cat)
 S_BASH=$(type -P bash)
-S_ECHO=$(type -P echo)
 S_PRINTF=$(type -P printf)
 S_WHOAMI=$(type -P whoami)
 S_DATE=$(type -P date)
@@ -45,67 +44,67 @@ S_BC=$(type -P bc)
 S_SLEEP=$(type -P sleep)
 
 if [[ ! -x $S_PS ]]; then
-  ${S_ECHO} "Utility 'ps' not found. Please, install it first."
+  echo "Utility 'ps' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_GREP ]]; then
-  ${S_ECHO} "Utility 'grep' not found. Please, install it first."
+  echo "Utility 'grep' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_AWK ]]; then
-  ${S_ECHO} "Utility 'awk' not found. Please, install it first."
+  echo "Utility 'awk' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_SORT ]]; then
-  ${S_ECHO} "Utility 'sort' not found. Please, install it first."
+  echo "Utility 'sort' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_UNIQ ]]; then
-  ${S_ECHO} "Utility 'uniq' not found. Please, install it first."
+  echo "Utility 'uniq' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_HEAD ]]; then
-  ${S_ECHO} "Utility 'head' not found. Please, install it first."
+  echo "Utility 'head' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_LSOF ]]; then
-  ${S_ECHO} "Utility 'lsof' not found. Please, install it first."
+  echo "Utility 'lsof' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_JQ ]]; then
-  ${S_ECHO} "Utility 'jq' not found. Please, install it first."
+  echo "Utility 'jq' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x ${S_DIRNAME} ]]; then
-  ${S_ECHO} "Utility 'dirname' not found. Please, install it first."
+  echo "Utility 'dirname' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x ${S_CAT} ]]; then
-  ${S_ECHO} "Utility 'cat' not found. Please, install it first."
+  echo "Utility 'cat' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x ${S_BASH} ]]; then
-  ${S_ECHO} "Utility 'bash' not found. Please, install it first."
+  echo "Utility 'bash' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x ${S_PRINTF} ]]; then
-  ${S_ECHO} "Utility 'printf' not found. Please, install it first."
+  echo "Utility 'printf' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x ${S_WHOAMI} ]]; then
-  ${S_ECHO} "Utility 'whoami' not found. Please, install it first."
+  echo "Utility 'whoami' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x ${S_DATE} ]]; then
-  ${S_ECHO} "Utility 'date' not found. Please, install it first."
+  echo "Utility 'date' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_BC ]]; then
-  $S_ECHO "Utility 'bc' not found. Please, install it first."
+  echo "Utility 'bc' not found. Please, install it first."
   exit 1
 fi
 if [[ ! -x $S_SLEEP ]]; then
-  $S_ECHO "Utility 'sleep' not found. Please, install it first."
+  echo "Utility 'sleep' not found. Please, install it first."
   exit 1
 fi
 
@@ -133,7 +132,7 @@ ACTIVE_USER=$(${S_WHOAMI})
 # Prints a string on screen. Works only if debug mode is enabled.
 function PrintDebug() {
   if [[ -n $DEBUG_MODE ]] && [[ -n $1 ]]; then
-    ${S_ECHO} "$1"
+    echo "$1"
   fi
 }
 
@@ -149,8 +148,8 @@ function EncodeToJson() {
     return 0
   fi
 
-  JSON_POOL=$(${S_ECHO} -n "$POOL_NAME" | ${S_JQ} -aR .)
-  JSON_SOCKET=$(${S_ECHO} -n "$POOL_SOCKET" | ${S_JQ} -aR .)
+  JSON_POOL=$(echo -n "$POOL_NAME" | ${S_JQ} -aR .)
+  JSON_SOCKET=$(echo -n "$POOL_SOCKET" | ${S_JQ} -aR .)
   if [[ ${POOL_FIRST} == 1 ]]; then
     RESULT_DATA="$RESULT_DATA,"
   fi
@@ -177,11 +176,11 @@ function UpdatePoolInCache() {
   for ITEM_INDEX in "${!CACHE[@]}"; do
     CACHE_ITEM="${CACHE[$ITEM_INDEX]}"
     # shellcheck disable=SC2016
-    ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
+    ITEM_NAME=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $1}')
     # shellcheck disable=SC2016
-    ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
+    ITEM_SOCKET=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $2}')
     # shellcheck disable=SC2016
-    ITEM_POOL_TYPE=$($S_ECHO "$CACHE_ITEM" | ${S_AWK} '{print $3}')
+    ITEM_POOL_TYPE=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $3}')
     if [[ $ITEM_NAME == "$POOL_NAME" && $ITEM_SOCKET == "$POOL_SOCKET" ]] || [[ -z $ITEM_POOL_TYPE ]]; then
       PrintDebug "Pool $POOL_NAME $POOL_SOCKET is in cache, deleting..."
       #Deleting the pool first
@@ -199,11 +198,11 @@ function UpdateCacheList() {
   for ITEM_INDEX in "${!CACHE[@]}"; do
     CACHE_ITEM="${CACHE[$ITEM_INDEX]}"
     # shellcheck disable=SC2016
-    ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
+    ITEM_NAME=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $1}')
     # shellcheck disable=SC2016
-    ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
+    ITEM_SOCKET=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $2}')
     # shellcheck disable=SC2016
-    ITEM_POOL_TYPE=$($S_ECHO "$CACHE_ITEM" | ${S_AWK} '{print $3}')
+    ITEM_POOL_TYPE=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $3}')
 
     if [[ $ITEM_NAME == "$POOL_NAME" && $ITEM_SOCKET == "$POOL_SOCKET" ]] || [[ -z $ITEM_POOL_TYPE ]]; then
       PrintDebug "Pool $POOL_NAME $POOL_SOCKET is in cache, deleting..."
@@ -289,7 +288,7 @@ function DeletePoolFromPendingList() {
 function SavePrintResults() {
   #Saving pending list:
   if [[ -f $PENDING_FILE ]] && [[ ! -w $PENDING_FILE ]]; then
-    ${S_ECHO} "Error: write permission is not granted to user $ACTIVE_USER for cache file $PENDING_FILE"
+    echo "Error: write permission is not granted to user $ACTIVE_USER for cache file $PENDING_FILE"
     exit 1
   fi
 
@@ -302,7 +301,7 @@ function SavePrintResults() {
   fi
 
   if [[ -f $RESULTS_CACHE_FILE ]] && [[ ! -w $RESULTS_CACHE_FILE ]]; then
-    ${S_ECHO} "Error: write permission is not granted to user $ACTIVE_USER for cache file $RESULTS_CACHE_FILE"
+    echo "Error: write permission is not granted to user $ACTIVE_USER for cache file $RESULTS_CACHE_FILE"
     exit 1
   fi
 
@@ -315,20 +314,20 @@ function SavePrintResults() {
 
   for CACHE_ITEM in "${CACHE[@]}"; do
     # shellcheck disable=SC2016
-    ITEM_NAME=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $1}')
+    ITEM_NAME=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $1}')
     # shellcheck disable=SC2016
-    ITEM_SOCKET=$(${S_ECHO} "$CACHE_ITEM" | ${S_AWK} '{print $2}')
+    ITEM_SOCKET=$(echo "$CACHE_ITEM" | ${S_AWK} '{print $2}')
     EncodeToJson "${ITEM_NAME}" "${ITEM_SOCKET}"
   done
 
   RESULT_DATA="$RESULT_DATA]}"
   PrintDebug "Resulting JSON data for Zabbix:"
-  ${S_ECHO} -n "$RESULT_DATA"
+  echo -n "$RESULT_DATA"
 }
 
 function CheckExecutionTime() {
   CURRENT_TIME=$($S_DATE +%s)
-  ELAPSED_TIME=$($S_ECHO "$CURRENT_TIME - $START_TIME" | $S_BC)
+  ELAPSED_TIME=$(echo "$CURRENT_TIME - $START_TIME" | $S_BC)
   if [[ $ELAPSED_TIME -lt $MAX_EXECUTION_TIME ]]; then
     #All good, we can continue
     PrintDebug "Check execution time OK"
@@ -363,10 +362,10 @@ function CheckPool() {
     # JSON data example:
     # {"pool":"www2","process manager":"ondemand","start time":1578181845,"start since":117,"accepted conn":3,"listen queue":0,"max listen queue":0,"listen queue len":0,"idle processes":0,"active processes":1,"total processes":1,"max active processes":1,"max children reached":0,"slow requests":0}
     # We use basic regular expression here, i.e. we need to use \+ and not escape { and }
-    if [[ -n $(${S_ECHO} "${STATUS_JSON}" | ${S_GREP} -G '^{.*\"pool\":\".\+\".*,\"process manager\":\".\+\".*}$') ]]; then
+    if [[ -n $(echo "${STATUS_JSON}" | ${S_GREP} -G '^{.*\"pool\":\".\+\".*,\"process manager\":\".\+\".*}$') ]]; then
       PrintDebug "Status data for pool $POOL_NAME, socket $POOL_SOCKET, status path $STATUS_PATH is valid"
 
-      PROCESS_MANAGER=$($S_ECHO "$STATUS_JSON" | $S_GREP -oP '"process manager":"\K([a-z]+)')
+      PROCESS_MANAGER=$(echo "$STATUS_JSON" | $S_GREP -oP '"process manager":"\K([a-z]+)')
       if [[ -n $PROCESS_MANAGER ]]; then
         PrintDebug "Detected pool's process manager is $PROCESS_MANAGER"
         UpdatePoolInCache "$POOL_NAME" "$POOL_SOCKET" "$PROCESS_MANAGER"
@@ -441,9 +440,9 @@ function AnalyzePool() {
       if [[ -n $pool ]]; then
         PrintDebug "Checking process: $pool"
         # shellcheck disable=SC2016
-        POOL_TYPE=$(${S_ECHO} "${pool}" | $S_AWK '{print $5}')
+        POOL_TYPE=$(echo "${pool}" | $S_AWK '{print $5}')
         # shellcheck disable=SC2016
-        POOL_SOCKET=$(${S_ECHO} "${pool}" | $S_AWK '{print $9}')
+        POOL_SOCKET=$(echo "${pool}" | $S_AWK '{print $9}')
         if [[ -n $POOL_TYPE ]] && [[ -n $POOL_SOCKET ]]; then
           if [[ $POOL_TYPE == "unix" ]]; then
             #We have a socket here, test if it's actually a socket:
@@ -457,10 +456,10 @@ function AnalyzePool() {
           elif [[ $POOL_TYPE == "IPv4" ]] || [[ $POOL_TYPE == "IPv6" ]]; then
             #We have a TCP connection here, check it:
             # shellcheck disable=SC2016
-            CONNECTION_TYPE=$(${S_ECHO} "${pool}" | $S_AWK '{print $8}')
+            CONNECTION_TYPE=$(echo "${pool}" | $S_AWK '{print $8}')
             if [[ $CONNECTION_TYPE == "TCP" ]]; then
               #The connection must have state LISTEN:
-              LISTEN=$(${S_ECHO} "${pool}" | $S_GREP -F -w "(LISTEN)")
+              LISTEN=$(echo "${pool}" | $S_GREP -F -w "(LISTEN)")
               if [[ -n $LISTEN ]]; then
                 #Check and replace * to localhost if it's found. Asterisk means that the PHP listens on
                 #all interfaces.
@@ -500,12 +499,12 @@ function PrintPendingList() {
   COUNTER=1
   for POOL_ITEM in "${PENDING_LIST[@]}"; do
     # shellcheck disable=SC2016
-    POOL_NAME=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $1}')
+    POOL_NAME=$(echo "$POOL_ITEM" | $S_AWK '{print $1}')
     # shellcheck disable=SC2016
-    POOL_SOCKET=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $2}')
+    POOL_SOCKET=$(echo "$POOL_ITEM" | $S_AWK '{print $2}')
     if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]]; then
       PrintDebug "#$COUNTER $POOL_NAME $POOL_SOCKET"
-      COUNTER=$($S_ECHO "$COUNTER + 1" | $S_BC)
+      COUNTER=$(echo "$COUNTER + 1" | $S_BC)
     fi
   done
 }
@@ -515,14 +514,14 @@ function PrintCacheList() {
   COUNTER=1
   for POOL_ITEM in "${CACHE[@]}"; do
     # shellcheck disable=SC2016
-    POOL_NAME=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $1}')
+    POOL_NAME=$(echo "$POOL_ITEM" | $S_AWK '{print $1}')
     # shellcheck disable=SC2016
-    POOL_SOCKET=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $2}')
+    POOL_SOCKET=$(echo "$POOL_ITEM" | $S_AWK '{print $2}')
     # shellcheck disable=SC2016
-    PROCESS_MANAGER=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $3}')
+    PROCESS_MANAGER=$(echo "$POOL_ITEM" | $S_AWK '{print $3}')
     if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]] && [[ -n "$PROCESS_MANAGER" ]]; then
       PrintDebug "#$COUNTER $POOL_NAME $POOL_SOCKET $PROCESS_MANAGER"
-      COUNTER=$($S_ECHO "$COUNTER + 1" | $S_BC)
+      COUNTER=$(echo "$COUNTER + 1" | $S_BC)
     fi
   done
 }
@@ -553,10 +552,10 @@ function ProcessPool() {
 for ARG in "$@"; do
   if [[ ${ARG} == "debug" ]]; then
     DEBUG_MODE="1"
-    ${S_ECHO} "Debug mode enabled"
+    echo "Debug mode enabled"
   elif [[ ${ARG} == "sleep" ]]; then
     USE_SLEEP_TIMEOUT="1"
-    ${S_ECHO} "Debug: Sleep timeout enabled"
+    echo "Debug: Sleep timeout enabled"
   elif [[ ${ARG} == /* ]]; then
     STATUS_PATH=${ARG}
     PrintDebug "Argument $ARG is interpreted as status path"
@@ -569,11 +568,11 @@ PrintDebug "Status path to be used: $STATUS_PATH"
 
 PrintDebug "Local directory is $LOCAL_DIR"
 if [[ ! -f ${STATUS_SCRIPT} ]]; then
-  ${S_ECHO} "Helper script $STATUS_SCRIPT not found"
+  echo "Helper script $STATUS_SCRIPT not found"
   exit 1
 fi
 if [[ ! -r ${STATUS_SCRIPT} ]]; then
-  ${S_ECHO} "Helper script $STATUS_SCRIPT is not readable"
+  echo "Helper script $STATUS_SCRIPT is not readable"
   exit 1
 fi
 PrintDebug "Helper script $STATUS_SCRIPT is reachable"
@@ -625,9 +624,9 @@ PrintDebug "Processing pools"
 
 for POOL_ITEM in "${PENDING_LIST[@]}"; do
   # shellcheck disable=SC2016
-  POOL_NAME=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $1}')
+  POOL_NAME=$(echo "$POOL_ITEM" | $S_AWK '{print $1}')
   # shellcheck disable=SC2016
-  POOL_SOCKET=$($S_ECHO "$POOL_ITEM" | $S_AWK '{print $2}')
+  POOL_SOCKET=$(echo "$POOL_ITEM" | $S_AWK '{print $2}')
   if [[ -n "$POOL_NAME" ]] && [[ -n "$POOL_SOCKET" ]]; then
     ProcessPool "$POOL_NAME" "$POOL_SOCKET"
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -25,6 +25,15 @@ USE_SLEEP_TIMEOUT=""
 #Sleep timeout in seconds
 SLEEP_TIMEOUT="0.5"
 
+#Parent directory where all cache files are located in the OS
+CACHE_ROOT="/var/cache"
+
+#Name of the private directory to store the cache files
+CACHE_DIR_NAME="zabbix-php-fpm"
+
+#Full path to directory to store cache files
+CACHE_DIRECTORY="$CACHE_ROOT/$CACHE_DIR_NAME"
+
 #Checking all the required executables
 S_PS=$(type -P ps)
 S_GREP=$(type -P grep)
@@ -118,18 +127,42 @@ if [[ "${BASH_VERSINFO:-0}" -lt 4 ]]; then
   exit 1
 fi
 
+if [[ ! -d "$CACHE_ROOT" ]]; then
+  ${S_ECHO} "The OS cache directory '$CACHE_ROOT' not found in the system."
+  exit 1
+fi
+
+function createCacheDirectory() {
+  if [[ ! -d "$CACHE_DIRECTORY" ]]; then
+    mkdir "$CACHE_DIRECTORY"
+  fi
+  if [[ ! -d "$CACHE_DIRECTORY" ]]; then
+    return 1
+  fi
+
+  chmod 700 "$CACHE_DIRECTORY"
+  return 0
+}
+
+createCacheDirectory
+EXIT_CODE=$?
+if [[ ${EXIT_CODE} -ne 0 ]]; then
+  ${S_ECHO} "Failed to create cache directory '$CACHE_DIRECTORY'."
+  exit 1
+fi
+
 #Local directory
 LOCAL_DIR=$(${S_DIRNAME} "$0")
 
 #Cache file for pending pools, used to store execution state
 #File format:
 #<pool name> <socket or TCP>
-PENDING_FILE="$LOCAL_DIR/php_fpm_pending.cache"
+PENDING_FILE="$CACHE_DIRECTORY/php_fpm_pending.cache"
 
 #Cache file with list of active pools, used to store execution state
 #File format:
 #<pool name> <socket or TCP> <pool manager type>
-RESULTS_CACHE_FILE="$LOCAL_DIR/php_fpm_results.cache"
+RESULTS_CACHE_FILE="$CACHE_DIRECTORY/php_fpm_results.cache"
 
 #Path to status script, another script of this bundle
 STATUS_SCRIPT="$LOCAL_DIR/zabbix_php_fpm_status.sh"
@@ -331,6 +364,9 @@ function DeletePoolFromPendingList() {
 }
 
 function SavePrintResults() {
+  #Checking and creating cache directory just in case:
+  createCacheDirectory
+
   #Saving pending list:
   if [[ -f $PENDING_FILE ]] && [[ ! -w $PENDING_FILE ]]; then
     echo "Error: write permission is not granted to user $ACTIVE_USER for cache file $PENDING_FILE"

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -7,11 +7,11 @@
 # Zabbix allows us to use a script that runs no more than 3 seconds by default. This option can be adjusted in settings:
 # see Timeout option https://www.zabbix.com/forum/zabbix-help/1284-server-agentd-timeout-parameter-in-config
 # So, we need to stop and save our state in case we need more time to run.
-# This parameter sets the maximum number of seconds that the script is allowed to run.
+# This parameter sets the maximum number of milliseconds that the script is allowed to run.
 # After this duration is reached, the script will stop running and save its state.
 # So, the actual execution time will be slightly more than this parameter.
-# We put value equivalent to 2 seconds here.
-MAX_EXECUTION_TIME="2"
+# We put value equivalent to 1.5 seconds here.
+MAX_EXECUTION_TIME="1500"
 
 #Status path used in calls to PHP-FPM
 STATUS_PATH="/php-fpm-status"
@@ -130,7 +130,7 @@ RESULTS_CACHE_FILE="$LOCAL_DIR/php_fpm_results.cache"
 STATUS_SCRIPT="$LOCAL_DIR/zabbix_php_fpm_status.sh"
 
 #Start time of the script
-START_TIME=$($S_DATE +%s)
+START_TIME=$($S_DATE +%s%N)
 
 ACTIVE_USER=$(${S_WHOAMI})
 
@@ -334,16 +334,16 @@ function SavePrintResults() {
 }
 
 function CheckExecutionTime() {
-  CURRENT_TIME=$($S_DATE +%s)
-  ELAPSED_TIME=$(echo "$CURRENT_TIME - $START_TIME" | $S_BC)
+  CURRENT_TIME=$($S_DATE +%s%N)
+  ELAPSED_TIME=$(echo "($CURRENT_TIME - $START_TIME)/1000000" | $S_BC)
   if [[ $ELAPSED_TIME -lt $MAX_EXECUTION_TIME ]]; then
     #All good, we can continue
-    PrintDebug "Check execution time OK, elapsed $ELAPSED_TIME"
+    PrintDebug "Check execution time OK, elapsed $ELAPSED_TIME ms"
     return 1
   fi
 
   #We need to save our state and exit
-  PrintDebug "Check execution time: stop required, elapsed $ELAPSED_TIME"
+  PrintDebug "Check execution time: stop required, elapsed $ELAPSED_TIME ms"
 
   SavePrintResults
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -44,67 +44,67 @@ S_DATE=$(type -P date)
 S_BC=$(type -P bc)
 S_SLEEP=$(type -P sleep)
 
-if [[ ! -f $S_PS ]]; then
+if [[ ! -x $S_PS ]]; then
   ${S_ECHO} "Utility 'ps' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_GREP ]]; then
+if [[ ! -x $S_GREP ]]; then
   ${S_ECHO} "Utility 'grep' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_AWK ]]; then
+if [[ ! -x $S_AWK ]]; then
   ${S_ECHO} "Utility 'awk' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_SORT ]]; then
+if [[ ! -x $S_SORT ]]; then
   ${S_ECHO} "Utility 'sort' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_UNIQ ]]; then
+if [[ ! -x $S_UNIQ ]]; then
   ${S_ECHO} "Utility 'uniq' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_HEAD ]]; then
+if [[ ! -x $S_HEAD ]]; then
   ${S_ECHO} "Utility 'head' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_LSOF ]]; then
+if [[ ! -x $S_LSOF ]]; then
   ${S_ECHO} "Utility 'lsof' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_JQ ]]; then
+if [[ ! -x $S_JQ ]]; then
   ${S_ECHO} "Utility 'jq' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f ${S_DIRNAME} ]]; then
+if [[ ! -x ${S_DIRNAME} ]]; then
   ${S_ECHO} "Utility 'dirname' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f ${S_CAT} ]]; then
+if [[ ! -x ${S_CAT} ]]; then
   ${S_ECHO} "Utility 'cat' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f ${S_BASH} ]]; then
+if [[ ! -x ${S_BASH} ]]; then
   ${S_ECHO} "Utility 'bash' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f ${S_PRINTF} ]]; then
+if [[ ! -x ${S_PRINTF} ]]; then
   ${S_ECHO} "Utility 'printf' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f ${S_WHOAMI} ]]; then
+if [[ ! -x ${S_WHOAMI} ]]; then
   ${S_ECHO} "Utility 'whoami' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f ${S_DATE} ]]; then
+if [[ ! -x ${S_DATE} ]]; then
   ${S_ECHO} "Utility 'date' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_BC ]]; then
+if [[ ! -x $S_BC ]]; then
   $S_ECHO "Utility 'bc' not found. Please, install it first."
   exit 1
 fi
-if [[ ! -f $S_SLEEP ]]; then
+if [[ ! -x $S_SLEEP ]]; then
   $S_ECHO "Utility 'sleep' not found. Please, install it first."
   exit 1
 fi

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -401,6 +401,7 @@ function sleepNow() {
   if [[ -n $USE_SLEEP_TIMEOUT ]]; then
     PrintDebug "Debug: Sleep for $SLEEP_TIMEOUT sec"
     $S_SLEEP "$SLEEP_TIMEOUT"
+    CheckExecutionTime
   fi
 }
 

--- a/zabbix/zabbix_php_fpm_discovery.sh
+++ b/zabbix/zabbix_php_fpm_discovery.sh
@@ -300,6 +300,9 @@ function SavePrintResults() {
   PrintDebug "Saving pending pools list to file $PENDING_FILE..."
   ${S_PRINTF} "%s\n" "${PENDING_LIST[@]}" >"$PENDING_FILE"
 
+  #We must sort the cache list
+  readarray -t CACHE < <(for a in "${CACHE[@]}"; do echo "$a"; done | sort)
+
   if [[ -n $DEBUG_MODE ]]; then
     PrintDebug "List of pools to be saved to cache pools file:"
     PrintCacheList

--- a/zabbix/zabbix_php_fpm_status.sh
+++ b/zabbix/zabbix_php_fpm_status.sh
@@ -6,12 +6,12 @@
 S_FCGI=$(type -P cgi-fcgi)
 S_GREP=$(type -P grep)
 
-if [[ ! -f $S_FCGI ]]; then
+if [[ ! -x $S_FCGI ]]; then
   echo "Utility 'cgi-fcgi' not found. Please, install it first."
   exit 1
 fi
 
-if [[ ! -f $S_GREP ]]; then
+if [[ ! -x $S_GREP ]]; then
   echo "Utility 'grep' not found. Please, install it first."
   exit 1
 fi


### PR DESCRIPTION
# Primary feature

For large number of pools the script can work for too much time. This PR should resolve this issue. The script saves its state and can continue to work properly between sequential calls. The default timeout of the Zabbix agent is 3 seconds. The script tries to fit into 1.5 seconds frame. However, there's a minimal amount of time that the script can work. This amount of time depends on:

- how powerful the computer is
- how many different PHP-FPM versions installed
- how many PHP-FPM pools are there
- if the computer is under heavy load.

In my tests performed with Travis CI, the minimal amount of time was in a range 4-11 seconds. That is beyond the default timeout. Therefore, the option `Timeout` in the file `/etc/zabbix/zabbix_agentd.conf` should be adjusted at least for 20 seconds.

See #31, closes #34 

# Extra enhancements
* [add] more asserts and checks
* [fix] PHP sockets detection in tests
* [fix] improved socket dir detection
* [fix] improved service name detection, code simplification
* [fix] socket pools check
* [fix] mapfile -d
* [add] local vars
* [add] Travis CI folds
* [add] color output in Travis CI log
* [add] more different tests: for static, dynamic, ondemand pools, etc.